### PR TITLE
Change cmake_minimum_required to 3.7.

### DIFF
--- a/prj/cmake/CMakeLists.txt
+++ b/prj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.7)
 
 option(SIMD "Use Simd Library" ON)
 option(SIMD_AVX512 "Use AVX-512" OFF)


### PR DESCRIPTION
Change cmake_minimum_required to 3.7 to get a clear error message. Because only since CMake 3.7 version supports "GREATER_EQUAL" command.