### PR TITLE
cmake: add RelWithDebInfo build type

### DIFF
--- a/prj/cmake/CMakeLists.txt
+++ b/prj/cmake/CMakeLists.txt
@@ -71,6 +71,8 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     set(COMMON_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -O3 -std=c++17 -fmax-errors=${MAX_ERRORS}")
+elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    set(COMMON_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -O2 -g -std=c++17 -fmax-errors=${MAX_ERRORS}")
 elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(COMMON_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -O0 -g -std=c++17 -fmax-errors=${MAX_ERRORS}")
 else()


### PR DESCRIPTION
Add support for the `RelWithDebInfo` build type in `prj/cmake/CMakeLists.txt`.

Previously only `Release` and `Debug` were accepted; any other `CMAKE_BUILD_TYPE` triggered a `FATAL_ERROR`. `RelWithDebInfo` now compiles with `-O2 -g` (optimized build with debug info).