### PR TITLE
Add Cloud Agent development environment for Synet

### DIFF
--- a/.cursor/env.sh
+++ b/.cursor/env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Shared configuration for the Synet Cloud Agent environment scripts.
+
+# CPU-only test targets built by install.sh (everything that does not require
+# the private OpenVINO/ONNX Runtime submodules).
+SYNET_CPU_TARGETS=(stability quantization optimizer performance_difference bf16 multi_threads video)
+
+# Location where the compiled build/ directory is cached, outside /workspace so
+# it survives the per-boot git checkout that wipes untracked files.
+SYNET_BUILD_CACHE="${HOME}/.cache/synet/build"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,5 @@
 {
   "name": "Synet",
-  "install": "bash .cursor/install.sh"
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Synet",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install script for Synet.
+#
+# Prepares a fresh checkout so the core framework and the CPU-only test
+# applications can be built and run. It is idempotent: re-running it reconfigures
+# and rebuilds incrementally, reusing the (slow) Simd compilation from cache.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# The base image's default C/C++ compiler alternative resolves to clang, which
+# cannot find libstdc++ in this image. Synet's build.sh hard-codes /usr/bin/c++,
+# so point the c++/cc alternatives at GCC. Guarded so it is a no-op when the
+# alternative is already set (e.g. baked into a snapshot) or sudo is unavailable.
+if command -v sudo >/dev/null 2>&1; then
+    sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-13 100 || true
+    sudo update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-13 100 || true
+    sudo update-alternatives --set c++ /usr/bin/g++-13 || true
+    sudo update-alternatives --set cc  /usr/bin/gcc-13 || true
+fi
+
+# Only the public dependencies (Simd, Cpl) are required for the core framework
+# and the CPU test applications. The OpenVINO and ONNX Runtime submodules use
+# SSH URLs to private forks and are intentionally left uninitialized here; enable
+# them separately (SSH access + the Conan flow in README.md) if you need the
+# test_inference_engine / test_onnx applications.
+git submodule update --init 3rd/Simd 3rd/Cpl
+
+# Build the core library plus every test application that does not depend on the
+# private OpenVINO/ONNX Runtime submodules. The first mode compiles Simd (the
+# slow part, several minutes); subsequent modes reuse the CMake cache and only
+# rebuild their small test executable.
+for mode in stability quantization optimizer performance_difference bf16 multi_threads video; do
+    echo "=== Building Synet test target: ${mode} ==="
+    bash build.sh "${mode}"
+done
+
+echo "=== Synet install complete. Built applications: ==="
+ls -1 build/test_* 2>/dev/null || true

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -2,14 +2,21 @@
 #
 # Cloud Agent install script for Synet.
 #
-# Prepares a fresh checkout so the core framework and the CPU-only test
-# applications can be built and run. It is idempotent: re-running it reconfigures
-# and rebuilds incrementally, reusing the (slow) Simd compilation from cache.
+# Builds the core framework and the CPU-only test applications, then caches the
+# compiled output outside /workspace so it survives the per-boot git checkout
+# (which wipes untracked files such as build/). The companion start.sh restores
+# the cache into /workspace/build on every boot.
+#
+# Idempotent: re-running reconfigures/rebuilds incrementally and refreshes the
+# cache.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+
+# shellcheck source=/dev/null
+source "$ROOT/.cursor/env.sh"
 
 # The base image's default C/C++ compiler alternative resolves to clang, which
 # cannot find libstdc++ in this image. Synet's build.sh hard-codes /usr/bin/c++,
@@ -33,10 +40,17 @@ git submodule update --init 3rd/Simd 3rd/Cpl
 # private OpenVINO/ONNX Runtime submodules. The first mode compiles Simd (the
 # slow part, several minutes); subsequent modes reuse the CMake cache and only
 # rebuild their small test executable.
-for mode in stability quantization optimizer performance_difference bf16 multi_threads video; do
+for mode in "${SYNET_CPU_TARGETS[@]}"; do
     echo "=== Building Synet test target: ${mode} ==="
     bash build.sh "${mode}"
 done
 
+# Cache the compiled output outside /workspace so future boots can restore it
+# without recompiling (a fresh checkout wipes the untracked build/ directory).
+echo "=== Caching build output to ${SYNET_BUILD_CACHE} ==="
+mkdir -p "$(dirname "$SYNET_BUILD_CACHE")"
+rm -rf "$SYNET_BUILD_CACHE"
+cp -a "$ROOT/build" "$SYNET_BUILD_CACHE"
+
 echo "=== Synet install complete. Built applications: ==="
-ls -1 build/test_* 2>/dev/null || true
+ls -1 "$ROOT"/build/test_* 2>/dev/null || true

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent start script for Synet.
+#
+# Runs on every boot after /workspace is checked out. The checkout wipes the
+# untracked build/ directory, so restore the compiled artifacts from the cache
+# populated by install.sh. Falls back to a full build if no cache exists (for
+# example a just-in-time run where install.sh has not populated the cache).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# shellcheck source=/dev/null
+source "$ROOT/.cursor/env.sh"
+
+# Submodule working trees normally survive via .git/modules, but restore them if
+# a boot dropped them so the build stays reproducible.
+if [ ! -f "$ROOT/3rd/Simd/prj/cmake/CMakeLists.txt" ] || [ ! -d "$ROOT/3rd/Cpl/src" ]; then
+    git submodule update --init 3rd/Simd 3rd/Cpl
+fi
+
+restore_from_cache() {
+    if [ -d "$SYNET_BUILD_CACHE" ] && ls "$SYNET_BUILD_CACHE"/test_* >/dev/null 2>&1; then
+        echo "=== Restoring Synet build from cache ${SYNET_BUILD_CACHE} ==="
+        if [ -e "$ROOT/build" ] && [ ! -d "$ROOT/build" ]; then
+            rm -f "$ROOT/build"
+        fi
+        rm -rf "$ROOT/build"
+        cp -a "$SYNET_BUILD_CACHE" "$ROOT/build"
+        return 0
+    fi
+    return 1
+}
+
+if ls "$ROOT"/build/test_* >/dev/null 2>&1; then
+    echo "=== Synet build already present in workspace ==="
+elif restore_from_cache; then
+    :
+else
+    echo "=== No cached build found; running full install ==="
+    bash "$ROOT/.cursor/install.sh"
+fi
+
+echo "=== Synet applications available: ==="
+ls -1 "$ROOT"/build/test_* 2>/dev/null || true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent environment so Synet can be built and exercised end to end in a fresh VM. It builds the core framework and the CPU-only test applications from the public `Simd` and `Cpl` submodules, and caches the compiled output so it survives across boots.

## What was added (all under `.cursor/`)

- `environment.json` — repository-managed environment using Cursor's default base image, with `install` and `start` hooks.
- `env.sh` — shared config: the list of CPU test targets and the build-cache location.
- `install.sh` — idempotent setup that:
  - Repoints the `c++`/`cc` alternatives to GCC. The base image's default `c++` resolves to `clang`, which cannot find `libstdc++` here, and `build.sh` hard-codes `/usr/bin/c++`.
  - Initializes only the public submodules (`3rd/Simd`, `3rd/Cpl`).
  - Builds `stability`, `quantization`, `optimizer`, `performance_difference`, `bf16`, `multi_threads`, and `video` via `build.sh` (the first target compiles Simd; later targets reuse the CMake cache).
  - Caches `build/` to `$HOME/.cache/synet/build` (outside `/workspace`).
- `start.sh` — runs on each boot and restores `build/` from the cache in seconds. A Cloud Agent re-checks out `/workspace` on every boot, which wipes the untracked `build/` directory; the cache lives outside `/workspace`, so it persists. Falls back to a full build if no cache exists.

## Scope / limitations

The `3rd/openvino` and `3rd/onnxruntime` submodules point at private forks over SSH (`git@github.com:Centimo/...`), and building OpenVINO/ONNX Runtime is very heavy, so they are intentionally left uninitialized. The `test_inference_engine` and `test_onnx` applications (and the `all` build mode) therefore aren't built by default; enable them separately via SSH access plus the Conan flow documented in `README.md`.

## Validation

- Clean `install` builds all 7 CPU test apps and caches them; re-running is idempotent.
- Two draft environment builds (`bld-...53d0af37`, `bld-...60984ad1`) completed with status `SUCCEEDED`, each compiling all 7 targets from a fresh checkout.
- `start.sh` restores `build/` from the cache in ~0.2s; the restored executables run correctly.
- End-to-end inference: `test_stability` loads a bundled Synet model and runs inference over real images → `Tests are finished successfully!` (exit 0).
- Graph optimizer: `test_optimizer -m=convert` optimizes a Synet model → `finished successfully` (exit 0).
- A fresh Cloud Agent booted from the tested build confirmed the correct GCC toolchain, submodule state, cached binaries, and both product actions.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89c07438-2c5c-4122-b51a-357ed6ffc958?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89c07438-2c5c-4122-b51a-357ed6ffc958&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

