### PR TITLE
Improve Synet.h C API type and function descriptions

### DIFF
--- a/src/Synet/Synet.h
+++ b/src/Synet/Synet.h
@@ -45,52 +45,67 @@ extern "C"
 #endif//__cplusplus
 
     /*! @ingroup c_api
-        Describes boolean type.
+        Describes a boolean value used by the C API.
+
+        Function parameters of this type enable or disable an option, and functions
+        returning this type report success/failure or another binary state.
     */
     typedef enum
     {
-        SynetFalse = 0, /*!< False value. */
-        SynetTrue = 1, /*!< True value. */
+        SynetFalse = 0, /*!< False, disabled or failed state. */
+        SynetTrue = 1, /*!< True, enabled or successful state. */
     } SynetBool;
 
     /*! @ingroup c_api
-        Describes logger level type.
+        Describes console logger verbosity used by ::SynetSetConsoleLogLevel.
+
+        Higher values include messages of all lower levels. ::SynetLogNone disables
+        console logging. Levels map to the internal Cpl logger writers attached to
+        <tt>std::cout</tt>.
     */
     typedef enum
     {
-        SynetLogNone = 0, /*!< Silence mode. */
-        SynetLogError,  /*!< Log errors. */
-        SynetLogWarning, /*!< Log warings. */
-        SynetLogInfo, /*!< Log info messages. */
-        SynetLogVerbose, /*!< Log verbose messages. */
+        SynetLogNone = 0, /*!< Disable console logging (silence mode). */
+        SynetLogError,  /*!< Log error messages. */
+        SynetLogWarning, /*!< Log warnings and more severe messages. */
+        SynetLogInfo, /*!< Log informational messages and above. */
+        SynetLogVerbose, /*!< Log verbose diagnostic messages and above. */
         SynetLogDebug, /*!< Log full debug information. */
     } SynetLogLevel;
 
     /*! @ingroup c_api
-        Describes tensor format.
+        Describes tensor memory layout used by network tensors.
+
+        Most network tensors are 4D with dimensions batch (N), channels (C), height (H)
+        and width (W). Layout selects whether channels are the outer or inner spatial
+        axis. ::SynetTensorFormatUnknown means the layout is unknown or irrelevant.
     */
     typedef enum
     {
-        SynetTensorFormatUnknown = -1, /*!< Unknown format. */
-        SynetTensorFormatNchw = 0, /*!< NCHW format. */
-        SynetTensorFormatNhwc, /*!< NHWC format. */
+        SynetTensorFormatUnknown = -1, /*!< Unknown or layout-independent tensor format. */
+        SynetTensorFormatNchw = 0, /*!< NCHW layout: offset = ((n*C + c)*H + h)*W + w. */
+        SynetTensorFormatNhwc, /*!< NHWC layout: offset = ((n*H + h)*W + w)*C + c. */
     } SynetTensorFormat;
 
     /*! @ingroup c_api
-        Describes tensor data type.
+        Describes tensor element data type used by network tensors.
+
+        The value defines interpretation and size of each tensor element. Reduced
+        precision values ::SynetTensorType16b and ::SynetTensorType16f are stored in
+        16-bit containers.
     */
     typedef enum
     {
         SynetTensorTypeUnknown = -1, /*!< Unknown tensor data type. */
-        SynetTensorType32f = 0, /*!< FP32 tensor data type. */
-        SynetTensorType32i, /*!< Signed INT32 tensor data type. */
-        SynetTensorType8i, /*!< Signed INT8 tensor data type. */
-        SynetTensorType8u, /*!< Unsigned INT8 tensor data type. */
-        SynetTensorType64i, /*!< Signed INT64 tensor data type. */
-        SynetTensorType64u, /*!< Unsigned INT64 tensor data type. */
-        SynetTensorTypeBool, /*!< Boolean (1-byte) tensor data type. */
-        SynetTensorType16b, /*!< 16-bit BFloat16 (Brain Floating Point). */
-        SynetTensorType16f, /*!< 16-bit floating point (Half Precision). */
+        SynetTensorType32f = 0, /*!< 32-bit floating point (single precision). */
+        SynetTensorType32i, /*!< 32-bit signed integer. */
+        SynetTensorType8i, /*!< 8-bit signed integer. */
+        SynetTensorType8u, /*!< 8-bit unsigned integer. */
+        SynetTensorType64i, /*!< 64-bit signed integer. */
+        SynetTensorType64u, /*!< 64-bit unsigned integer. */
+        SynetTensorTypeBool, /*!< Boolean value stored in one byte. */
+        SynetTensorType16b, /*!< 16-bit BFloat16 (Brain Floating Point) stored in a 16-bit container. */
+        SynetTensorType16f, /*!< 16-bit floating point (Half Precision) stored in a 16-bit container. */
     } SynetTensorType;
 
     /*! @ingroup c_api
@@ -99,7 +114,14 @@ extern "C"
 
         \short Gets version of %Synet Framework.
 
-        \return string with version of %Synet.
+        Returns a pointer to a null-terminated string that encodes the framework version.
+        The string is produced at build time from the project version file and typically
+        has the form <tt>"major.minor.release[.date.branch-sha]"</tt> (for example
+        <tt>"1.0.8.2026-08-12.HEAD-d3530fc0"</tt>).
+
+        The returned pointer is valid for the lifetime of the process and must not be freed.
+
+        \return a pointer to a static null-terminated string with the version of %Synet Framework.
     */
     SYNET_API const char* SynetVersion();
 
@@ -107,9 +129,13 @@ extern "C"
 
         \fn void SynetSetConsoleLogLevel(SynetLogLevel level);
 
-        \short Sets level of console(std::cout) logger of %Synet Framework.
+        \short Sets the console (<tt>std::cout</tt>) logger level of %Synet Framework.
 
-        \param [in] level - a level of console(std::cout) logger.
+        Replaces any previously installed console log writer with a writer that accepts
+        messages at or above \a level. Pass ::SynetLogNone to suppress console output.
+        See ::SynetLogLevel for the available levels.
+
+        \param [in] level - a console logger level (see ::SynetLogLevel).
     */
     SYNET_API void SynetSetConsoleLogLevel(SynetLogLevel level);
 
@@ -117,9 +143,20 @@ extern "C"
 
         \fn void SynetRelease(void * context);
 
-        \short Releases context created with using of Synet Framework API.
+        \short Destroys an opaque context object created by the Synet Framework C API.
 
-        \param [in] context - a context to be released.
+        Releases any context returned by a Synet Framework context-creation function,
+        currently ::SynetNetworkInit. Internally the function performs a polymorphic
+        \c delete through the virtual destructor of the internal \c Deletable base class.
+
+        Passing \c NULL is safe and has no effect, consistent with the behaviour of a
+        C++ \c delete expression on a null pointer.
+
+        \note Passing a pointer that was not returned by a Synet Framework context-creation
+              function (for example a tensor pointer from ::SynetNetworkSrc / ::SynetNetworkDst,
+              or a pointer from \c malloc / \c new) is undefined behaviour.
+
+        \param [in] context - a pointer to the context to be released, or \c NULL.
     */ 
     SYNET_API void SynetRelease(void* context);
 
@@ -127,9 +164,23 @@ extern "C"
 
         \fn void * SynetNetworkInit();
 
-        \short Creates Synet Network.
+        \short Creates an empty Synet network context.
 
-        \return a pointer to Network. It must be released with using of function ::SynetRelease.
+        Allocates a network object that must later be filled with ::SynetNetworkLoad
+        before inference. The returned pointer is opaque for C clients and must be
+        released with ::SynetRelease when it is no longer needed.
+
+        Usage example:
+        \verbatim
+        void* network = SynetNetworkInit();
+        if (SynetNetworkLoad(network, "model.xml", "model.bin") == SynetTrue)
+        {
+            // fill inputs, run SynetNetworkForward, read outputs
+        }
+        SynetRelease(network);
+        \endverbatim
+
+        \return a pointer to a network context. It must be released with ::SynetRelease.
     */
     SYNET_API void * SynetNetworkInit();
 
@@ -137,12 +188,17 @@ extern "C"
 
         \fn SynetBool SynetNetworkLoad(void * network, const char * model, const char* weight);
 
-        \short Loads Synet model from files.
+        \short Loads a Synet model and its binary weights into a network context.
 
-        \param [in, out] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
-        \param [in] model - a path to Synet model description (in XML format).
-        \param [in] weight - a path to Synet model binary weights.
-        \return result of model loading.
+        Clears any previously loaded model in \a network, parses the XML model
+        description from \a model, creates layers and reads binary weights from
+        \a weight. On success the network is ready for reshape/batch changes,
+        input filling and ::SynetNetworkForward.
+
+        \param [in, out] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
+        \param [in] model - a path to the Synet model description file (XML format).
+        \param [in] weight - a path to the Synet model binary weights file.
+        \return ::SynetTrue on success, ::SynetFalse on failure.
     */
     SYNET_API SynetBool SynetNetworkLoad(void * network, const char * model, const char* weight);
 
@@ -150,10 +206,13 @@ extern "C"
 
         \fn SynetBool SynetNetworkEmpty(void * network);
 
-        \short Checks is network model loaded.
+        \short Checks whether a network context has no loaded model.
 
-        \param [in] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
-        \return result of checking.
+        Returns ::SynetTrue when \a network has not been successfully loaded (or was
+        cleared), and ::SynetFalse after a successful ::SynetNetworkLoad.
+
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
+        \return ::SynetTrue if the network is empty, ::SynetFalse if a model is loaded.
     */
     SYNET_API SynetBool SynetNetworkEmpty(void* network);
 
@@ -161,25 +220,35 @@ extern "C"
 
         \fn SynetBool SynetNetworkReshape(void* network, size_t width, size_t height, size_t batch);
 
-        \short Reshapes previously loaded network model.
+        \short Reshapes a previously loaded network for a new input size and batch.
 
-        \param [in] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
-        \param [in] width - a width of input tensor.
-        \param [in] height - a height of input tensor.
-        \param [in] batch - a batch size of input tensor.
-        \return result of the operation.
+        Updates the single 4D input tensor to the given \a width, \a height and
+        \a batch according to the model tensor format (::SynetTensorFormatNchw or
+        ::SynetTensorFormatNhwc), then rebuilds intermediate tensors. The network must
+        already be loaded, must have exactly one input, and that input must be
+        resizable (or already marked with dynamic spatial dimensions).
+
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
+        \param [in] width - a width of the input tensor.
+        \param [in] height - a height of the input tensor.
+        \param [in] batch - a batch size of the input tensor.
+        \return ::SynetTrue on success, ::SynetFalse on failure.
     */
     SYNET_API SynetBool SynetNetworkReshape(void* network, size_t width, size_t height, size_t batch);
 
     /*! @ingroup c_api
 
-        \fn  SynetBool SynetNetworkSetBatch(void* network, size_t batch);
+        \fn SynetBool SynetNetworkSetBatch(void* network, size_t batch);
 
-        \short Sets batch in previously loaded network model.
+        \short Sets the batch size of a previously loaded network model.
 
-        \param [in] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
-        \param [in] batch - a batch size of input tensor.
-        \return result of the operation.
+        Changes only the batch (N) dimension of the single network input and rebuilds
+        intermediate tensors. Spatial dimensions are left unchanged. The network must
+        already be loaded and must have exactly one input.
+
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
+        \param [in] batch - a batch size of the input tensor.
+        \return ::SynetTrue on success, ::SynetFalse on failure.
     */
     SYNET_API SynetBool SynetNetworkSetBatch(void* network, size_t batch);
 
@@ -187,10 +256,10 @@ extern "C"
 
         \fn size_t SynetNetworkSrcSize(void* network);
 
-        \short Gets number of network inputs.
+        \short Gets the number of network input tensors.
 
-        \param [in] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
-        \return a number of network inputs.
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
+        \return the number of network input tensors.
     */
     SYNET_API size_t SynetNetworkSrcSize(void* network);
 
@@ -198,11 +267,16 @@ extern "C"
 
         \fn void * SynetNetworkSrc(void* network, size_t index);
 
-        \short Gets pointer to given input tensor.
+        \short Gets a pointer to the input tensor at the given index.
 
-        \param [in] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
-        \param [in] index - an index of input tensor.
-        \return a pointer to given input tensor. It is valid until you reload or reshape model.
+        The returned opaque tensor pointer can be queried with ::SynetTensorCount,
+        ::SynetTensorAxis, ::SynetTensorFormatGet, ::SynetTensorTypeGet,
+        ::SynetTensorName and ::SynetTensorData. It remains valid until the model is
+        reloaded or reshaped. Do not release it with ::SynetRelease.
+
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
+        \param [in] index - a zero-based index of the input tensor; must be less than ::SynetNetworkSrcSize.
+        \return a pointer to the input tensor, or undefined if \a index is out of range.
     */
     SYNET_API void * SynetNetworkSrc(void* network, size_t index);
 
@@ -210,10 +284,10 @@ extern "C"
 
         \fn size_t SynetNetworkDstSize(void* network);
 
-        \short Gets number of network outputs.
+        \short Gets the number of network output tensors.
 
-        \param [in,out] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
-        \return a number of network outputs.
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
+        \return the number of network output tensors.
     */
     SYNET_API size_t SynetNetworkDstSize(void* network);
 
@@ -221,11 +295,16 @@ extern "C"
 
         \fn void * SynetNetworkDst(void* network, size_t index);
 
-        \short Gets pointer to given output tensor.
+        \short Gets a pointer to the output tensor at the given index.
 
-        \param [in] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
-        \param [in] index - an index of output tensor.
-        \return a pointer to given output tensor. It is valid until you reload or reshape model. Inference rewrites output tensors.
+        The returned opaque tensor pointer can be queried with the ::SynetTensor*
+        accessors. It remains valid until the model is reloaded or reshaped.
+        ::SynetNetworkForward overwrites output tensor contents. Do not release the
+        pointer with ::SynetRelease.
+
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
+        \param [in] index - a zero-based index of the output tensor; must be less than ::SynetNetworkDstSize.
+        \return a pointer to the output tensor, or undefined if \a index is out of range.
     */
     SYNET_API void* SynetNetworkDst(void* network, size_t index);
 
@@ -233,11 +312,16 @@ extern "C"
 
         \fn void * SynetNetworkDstByName(void* network, const char * name);
 
-        \short Gets pointer to output tensor with given name.
+        \short Gets a pointer to the output tensor with the given name.
 
-        \param [in] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
-        \param [in] name - an output tensor name.
-        \return a pointer to given output tensor. It is valid until you reload or reshape model. Inference rewrites output tensors.
+        Searches network outputs for a tensor whose name equals \a name. The returned
+        pointer has the same lifetime rules as ::SynetNetworkDst: it is valid until
+        reload/reshape, and inference overwrites its data. Do not release it with
+        ::SynetRelease.
+
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
+        \param [in] name - a null-terminated output tensor name.
+        \return a pointer to the matching output tensor, or \c NULL if no output with that name exists.
     */
     SYNET_API void* SynetNetworkDstByName(void* network, const char * name);
 
@@ -245,9 +329,13 @@ extern "C"
 
         \fn void SynetNetworkCompactWeight(void* network);
 
-        \short Reduces memory usage by model network. After calling of this function model can't be reshaped.
+        \short Reduces memory used by network weights after loading.
 
-        \param [in] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
+        Compacts layer weight storage and may clear unused constant tensors. Call this
+        after ::SynetNetworkLoad (and any required reshape/batch setup) when the model
+        shape is final. After this call the network should not be reshaped.
+
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
     */
     SYNET_API void SynetNetworkCompactWeight(void* network);
 
@@ -255,9 +343,14 @@ extern "C"
 
         \fn void SynetNetworkForward(void* network);
 
-        \short Performs network model inference.
+        \short Runs network inference.
 
-        \param [in] network - a network context. It is creted by function ::SynetNetworkInit and released by function ::SynetRelease.
+        Executes all network stages for the default thread. Input tensors obtained via
+        ::SynetNetworkSrc must be filled before calling this function. Output tensors
+        obtained via ::SynetNetworkDst / ::SynetNetworkDstByName are updated with the
+        inference results.
+
+        \param [in] network - a network context created by ::SynetNetworkInit and released by ::SynetRelease.
     */
     SYNET_API void SynetNetworkForward(void* network);
 
@@ -265,10 +358,10 @@ extern "C"
 
         \fn size_t SynetTensorCount(void* tensor);
 
-        \short Gets number of dimensions of tensor.
+        \short Gets the number of dimensions (rank) of a tensor.
 
-        \param [in] tensor - a tensor context. It is getted by functions ::SynetNetworkSrc or ::SynetNetworkDst.
-        \return a number of dimensions of tensor.
+        \param [in] tensor - a tensor pointer obtained from ::SynetNetworkSrc, ::SynetNetworkDst or ::SynetNetworkDstByName.
+        \return the number of dimensions of the tensor.
     */
     SYNET_API size_t SynetTensorCount(void* tensor);
 
@@ -276,11 +369,14 @@ extern "C"
 
         \fn size_t SynetTensorAxis(void* tensor, ptrdiff_t axis);
 
-        \short Gets size of given dimension of tensor.
+        \short Gets the size of a given tensor dimension.
 
-        \param [in] tensor - a tensor context. It is getted by functions ::SynetNetworkSrc or ::SynetNetworkDst.
-        \param [in] axis - an index of tensor dimension. Can be negative.
-        \return a size of given dimension of tensor.
+        \a axis may be negative and is then counted from the end (for example \c -1
+        selects the last dimension), matching the C++ tensor \c Axis helper.
+
+        \param [in] tensor - a tensor pointer obtained from ::SynetNetworkSrc, ::SynetNetworkDst or ::SynetNetworkDstByName.
+        \param [in] axis - an index of the tensor dimension; may be negative.
+        \return the size of the selected dimension.
     */
     SYNET_API size_t SynetTensorAxis(void* tensor, ptrdiff_t axis);
 
@@ -288,10 +384,10 @@ extern "C"
 
         \fn SynetTensorFormat SynetTensorFormatGet(void* tensor);
 
-        \short Gets tensor format.
+        \short Gets the memory layout of a tensor.
 
-        \param [in] tensor - a tensor context. It is getted by functions ::SynetNetworkSrc or ::SynetNetworkDst.
-        \return a tensor format.
+        \param [in] tensor - a tensor pointer obtained from ::SynetNetworkSrc, ::SynetNetworkDst or ::SynetNetworkDstByName.
+        \return the tensor format (see ::SynetTensorFormat).
     */
     SYNET_API SynetTensorFormat SynetTensorFormatGet(void* tensor);
 
@@ -299,10 +395,10 @@ extern "C"
 
         \fn SynetTensorType SynetTensorTypeGet(void* tensor);
 
-        \short Gets tensor data type.
+        \short Gets the element data type of a tensor.
 
-        \param [in] tensor - a tensor context. It is getted by functions ::SynetNetworkSrc or ::SynetNetworkDst.
-        \return a tensor data type.
+        \param [in] tensor - a tensor pointer obtained from ::SynetNetworkSrc, ::SynetNetworkDst or ::SynetNetworkDstByName.
+        \return the tensor data type (see ::SynetTensorType).
     */
     SYNET_API SynetTensorType SynetTensorTypeGet(void* tensor);
 
@@ -310,10 +406,14 @@ extern "C"
 
         \fn const char * SynetTensorName(void* tensor);
 
-        \short Gets tensor name.
+        \short Gets the name of a tensor.
 
-        \param [in] tensor - a tensor context. It is getted by functions ::SynetNetworkSrc or ::SynetNetworkDst.
-        \return a tensor name.
+        Returns a pointer to a null-terminated string owned by the tensor/network.
+        The pointer remains valid until the owning network is reloaded, reshaped or
+        released, and must not be freed by the caller.
+
+        \param [in] tensor - a tensor pointer obtained from ::SynetNetworkSrc, ::SynetNetworkDst or ::SynetNetworkDstByName.
+        \return a pointer to the tensor name.
     */
     SYNET_API const char * SynetTensorName(void* tensor);
 
@@ -321,10 +421,16 @@ extern "C"
 
         \fn uint8_t * SynetTensorData(void* tensor);
 
-        \short Gets pointer to tensor data.
+        \short Gets a pointer to the raw tensor data buffer.
 
-        \param [in] tensor - a tensor context. It is getted by functions ::SynetNetworkSrc or ::SynetNetworkDst.
-        \return a pointer to tensor data.
+        The buffer contains tightly packed elements whose type is reported by
+        ::SynetTensorTypeGet. For input tensors, write preprocessed values here before
+        ::SynetNetworkForward. For output tensors, read results after inference.
+        The pointer remains valid until the owning network is reloaded, reshaped or
+        released, and must not be freed by the caller.
+
+        \param [in] tensor - a tensor pointer obtained from ::SynetNetworkSrc, ::SynetNetworkDst or ::SynetNetworkDstByName.
+        \return a pointer to the tensor data buffer.
     */
     SYNET_API uint8_t * SynetTensorData(void* tensor);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves Doxygen descriptions for public C API types and functions in `src/Synet/Synet.h`, aligned with the documentation style used in Simd:

- Enumerations: `SynetBool`, `SynetLogLevel`, `SynetTensorFormat`, `SynetTensorType`
- Core helpers: `SynetVersion`, `SynetSetConsoleLogLevel`, `SynetRelease`
- Network API: init/load/empty/reshape/batch, src/dst accessors, compact weights, forward
- Tensor accessors: count/axis/format/type/name/data

Also fixes typos (`creted`, `warings`, `getted`), clarifies `SynetNetworkEmpty` semantics (returns true when empty), and documents tensor pointer lifetime / `NULL` release behaviour.

## Notes

- Changes are localized to `src/Synet/Synet.h`.
- No test suite run (documentation-only task).
- Code behavior is unchanged; only comments were updated.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8779ce93-1e81-41d2-bfd0-7db07ba98428?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8779ce93-1e81-41d2-bfd0-7db07ba98428&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

