### PR TITLE
*refactoring of ConvertCosNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertConstantNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertConstantOfShapeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertConvOrConvTransposeNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertCosNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertDequantizeLinearNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertDropoutNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertEqualNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertConvOrConvTransposeNode.cpp">
       <Filter>OnnxRuntime\C</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertCosNode.cpp">
+      <Filter>OnnxRuntime\C</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertDequantizeLinearNode.cpp">
       <Filter>OnnxRuntime\D</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -61,6 +61,8 @@ namespace Synet
 
     bool ConvertConvOrConvTransposeNode(const onnx::NodeProto& node, bool trans, LayerParams& layers, const Bytes& srcBin, LayerParam& layer, Bytes& dstBin, TensorFormatMap* tensorFormatMap, UniqNames& merged);
 
+    bool ConvertCosNode(const onnx::NodeProto& node, LayerParam& layer);
+
     bool ConvertBatchNormalizationNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes& original, LayerParam& layer, Bytes& reordered);
 
     bool ConvertDequantizeLinearNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const Bytes& original, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertCosNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertCosNode.cpp
@@ -1,0 +1,40 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertCosNode(const onnx::NodeProto& node, LayerParam& layer)
+    {
+        layer.type() = Synet::LayerTypeUnaryOperation;
+        layer.unaryOperation().type() = UnaryOperationTypeCos;
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,13 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertCosNode(const onnx::NodeProto& node, LayerParam& layer)
-        {
-            layer.type() = Synet::LayerTypeUnaryOperation;
-            layer.unaryOperation().type() = UnaryOperationTypeCos;
-            return true;
-        }
-
         bool ConvertDivNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer, Bytes& reordered)
         {
             if (!CheckSourceNumber(layer, 2))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertCosNode` out of `OnnxRuntime.h` into a dedicated `ConvertCosNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.

## Test plan
- [ ] Build `CvtOnnx` with VS2022 / project files that include the new `ConvertCosNode.cpp`.
- [ ] Confirm Cos ONNX nodes still convert to `LayerTypeUnaryOperation` with `UnaryOperationTypeCos`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2a6b192-2e33-4f15-9083-7d1f59cd18d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2a6b192-2e33-4f15-9083-7d1f59cd18d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

