### PR TITLE
*refactoring of ConvertExpandNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertEqualNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertErfNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertExpNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertExpandNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertFlattenNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertGatherNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertGemmNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertExpNode.cpp">
       <Filter>OnnxRuntime\E</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertExpandNode.cpp">
+      <Filter>OnnxRuntime\E</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertFlattenNode.cpp">
       <Filter>OnnxRuntime\F</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -77,6 +77,8 @@ namespace Synet
 
     bool ConvertExpNode(const onnx::NodeProto& node, LayerParam& layer);
 
+    bool ConvertExpandNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);
+
     bool ConvertFlattenNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertGatherNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertExpandNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertExpandNode.cpp
@@ -1,0 +1,65 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertExpandNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 2))
+            return false;
+        const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src0 == NULL || src1 == NULL)
+            return false;
+        if (src1->type() == LayerTypeMeta)
+        {
+            const MetaParam & meta = src1->meta();
+            if (meta.type() == MetaTypeConst && meta.alpha().type() == TensorType64i && AllEqualTo(meta.alpha().i64(), int64_t(1)))
+            {
+                layer.type() = Synet::LayerTypeStub;
+                layer.src().resize(1);
+            }
+            else if (meta.type() == MetaTypeConst && meta.alpha().type() == TensorType64i &&
+                src0->type() == LayerTypeConst && Shp(meta.alpha().i64()) == src0->weight()[0].dim())
+            {
+                layer.type() = Synet::LayerTypeStub;
+                layer.src().resize(1);
+            }
+            else
+            {
+                layer.type() = Synet::LayerTypeTile;
+            }
+        }
+        else
+            SYNET_ERROR("Unsupported src[1] type!");
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,38 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertExpandNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 2))
-                return false;
-            const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src0 == NULL || src1 == NULL)
-                return false;
-            if (src1->type() == LayerTypeMeta)
-            {
-                const MetaParam & meta = src1->meta();
-                if (meta.type() == MetaTypeConst && meta.alpha().type() == TensorType64i && AllEqualTo(meta.alpha().i64(), int64_t(1)))
-                {
-                    layer.type() = Synet::LayerTypeStub;
-                    layer.src().resize(1);
-                }
-                else if (meta.type() == MetaTypeConst && meta.alpha().type() == TensorType64i &&
-                    src0->type() == LayerTypeConst && Shp(meta.alpha().i64()) == src0->weight()[0].dim())
-                {
-                    layer.type() = Synet::LayerTypeStub;
-                    layer.src().resize(1);
-                }
-                else
-                {
-                    layer.type() = Synet::LayerTypeTile;
-                }
-            }
-            else
-                return false;
-            return true;
-        }
-
         bool ConvertFloorNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
         {
             if (!CheckSourceNumber(layer, 1))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertExpandNode` out of `OnnxRuntime.h` into a dedicated `ConvertExpandNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.
- Add `SYNET_ERROR("Unsupported src[1] type!")` when the second input is not a Meta layer. `CheckSourceNumber` and `GetLayer` already report their own errors.

## Test plan
- [ ] Build `CvtOnnx` with VS2022 / project files that include the new `ConvertExpandNode.cpp`.
- [ ] Confirm Expand ONNX nodes still convert: all-ones or matching-const shape to `LayerTypeStub`, otherwise to `LayerTypeTile`.
- [ ] Confirm a non-Meta `src[1]` reports the new unsupported-type error.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1e97a2a-d70e-465a-a99b-72ea552b5cc5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1e97a2a-d70e-465a-a99b-72ea552b5cc5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

