### PR TITLE
*refactoring of ConvertGridSampleNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertGemmNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertGlobalAveragePoolNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertGreaterNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertGridSampleNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertHardSwishNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInitializer.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInput.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -135,6 +135,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertGreaterNode.cpp">
       <Filter>OnnxRuntime\G</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertGridSampleNode.cpp">
+      <Filter>OnnxRuntime\G</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertHardSwishNode.cpp">
       <Filter>OnnxRuntime\H</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -91,6 +91,8 @@ namespace Synet
 
     bool ConvertGreaterNode(const onnx::NodeProto& node, LayerParam& layer);
 
+    bool ConvertGridSampleNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);
+
     bool ConvertHardSwishNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertInitializer(const onnx::TensorProto& tensor, Synet::NetworkParam& network, Bytes& weight, Renames& renames);

--- a/src/Cvt/OnnxRuntime/ConvertGridSampleNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertGridSampleNode.cpp
@@ -1,0 +1,73 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertGridSampleNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 2))
+            return false;
+        const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src0 == NULL || src1 == NULL)
+            return false;
+
+        layer.type() = LayerTypeGridSample;
+        if (!ConvertAtrributeInt(node, "align_corners", layer.gridSample().alignCorners()))
+            return false;
+
+        String interpMode;
+        if (!ConvertAtrributeString(node, "mode", interpMode))
+            return false;
+        if (interpMode == "bilinear")
+            layer.gridSample().interpMode() = GridSampleInterpModeBilinear;
+        else if (interpMode == "nearest")
+            layer.gridSample().interpMode() = GridSampleInterpModeNearest;
+        else if (interpMode == "bicubic")
+            layer.gridSample().interpMode() = GridSampleInterpModeBicubic;
+        else
+            SYNET_ERROR("Unsupported interpolation mode '" << interpMode << "' !");
+
+        String paddingMode;
+        if (!ConvertAtrributeString(node, "padding_mode", paddingMode))
+            return false;
+        if (paddingMode == "zeros")
+            layer.gridSample().paddingMode() = GridSamplePaddingModeZeros;
+        else if (paddingMode == "border")
+            layer.gridSample().paddingMode() = GridSamplePaddingModeBorder;
+        else if (paddingMode == "reflection")
+            layer.gridSample().paddingMode() = GridSamplePaddingModeReflection;
+        else
+            SYNET_ERROR("Unsupported padding mode '" << paddingMode << "' !");
+
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,46 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertGridSampleNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 2))
-                return false;
-            const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src0 == NULL || src1 == NULL)
-                return false;
-
-            layer.type() = LayerTypeGridSample;
-            if (!ConvertAtrributeInt(node, "align_corners", layer.gridSample().alignCorners()))
-                return false;
-
-            String interpMode;
-            if (!ConvertAtrributeString(node, "mode", interpMode))
-                return false;
-            if (interpMode == "bilinear")
-                layer.gridSample().interpMode() = GridSampleInterpModeBilinear;
-            else if (interpMode == "nearest")
-                layer.gridSample().interpMode() = GridSampleInterpModeNearest;
-            else if (interpMode == "bicubic")
-                layer.gridSample().interpMode() = GridSampleInterpModeBicubic;
-            else
-                return false;
-
-            String paddingMode;
-            if (!ConvertAtrributeString(node, "padding_mode", paddingMode))
-                return false;
-            if (paddingMode == "zeros")
-                layer.gridSample().paddingMode() = GridSamplePaddingModeZeros;
-            else if (paddingMode == "border")
-                layer.gridSample().paddingMode() = GridSamplePaddingModeBorder;
-            else if (paddingMode == "reflection")
-                layer.gridSample().paddingMode() = GridSamplePaddingModeReflection;
-            else
-                return false;
-
-            return true;
-        }
-
         bool ConvertHardSigmoidNode(const onnx::NodeProto& node, LayerParam& layer)
         {
             layer.type() = Synet::LayerTypeHardSigmoid;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertGridSampleNode` out of `OnnxRuntime.h` into a dedicated `ConvertGridSampleNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.
- `CheckSourceNumber`, `GetLayer`, `ConvertAtrributeInt`, and `ConvertAtrributeString` already report their own errors. Add `SYNET_ERROR` for unsupported interpolation modes and padding modes, which previously failed silently.

## Test plan
- [ ] Build `CvtOnnx` with VS2022 / project files that include the new `ConvertGridSampleNode.cpp`.
- [ ] Confirm GridSample ONNX nodes still convert: bilinear/nearest/bicubic interpolation and zeros/border/reflection padding, with `align_corners`.
- [ ] Confirm unknown interpolation or padding mode reports the new `SYNET_ERROR` message.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5685886d-1f8a-4cc7-b2be-3ecc36036756?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5685886d-1f8a-4cc7-b2be-3ecc36036756&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

