### PR TITLE
*use Simd::SynetAdd16b instead of Synet::Add16b.

### DIFF
--- a/src/Synet/Layers/Math/AddLayer.cpp
+++ b/src/Synet/Layers/Math/AddLayer.cpp
@@ -548,10 +548,12 @@ namespace Synet
             _addBias = GetAddBias(_typeA, _typeB, _typeD);
             if(_uniform == NULL || _addBias == NULL)
                 SYNET_ERROR("AddLayer can't process input type!");
+#if defined(SYNET_SIMD_LIBRARY_ENABLE)
             if (shapeA == shapeB)
-                _add16b.Init(shapeA, _typeA, shapeB, _typeB, _typeD, _format);
+                _add16b.Init(shapeA, (SimdTensorDataType)_typeA, shapeB, (SimdTensorDataType)_typeB, (SimdTensorDataType)_typeD, (SimdTensorFormatType)_format);
             else
                 _add16b.Clear();
+#endif
         }
 
         if (_src[0]->Const() && _src[1]->Const())
@@ -591,11 +593,13 @@ namespace Synet
             const uint8_t* srcA = _src[0]->RawData();
             const uint8_t* srcB = _src[1]->RawData();
             uint8_t* dst0 = dst[0]->RawData();
+#if defined(SYNET_SIMD_LIBRARY_ENABLE)
             if (_add16b.Enable())
             {
                 _add16b.Forward(srcA, srcB, dst0);
                 return;
             }
+#endif
             switch (_special)
             {
             case SpecialNone:

--- a/src/Synet/Layers/Math/AddLayer.h
+++ b/src/Synet/Layers/Math/AddLayer.h
@@ -26,7 +26,10 @@
 #pragma once
 
 #include "Synet/Layer.h"
-#include "Synet/Utils/Add.h"
+
+#if defined(SYNET_SIMD_LIBRARY_ENABLE)
+#include "Simd/SimdSynet.hpp"
+#endif
 
 namespace Synet
 {
@@ -75,6 +78,8 @@ namespace Synet
         UniformPtr _uniform;
         AddBiasPtr _addBias;
         UniversalPtr _universal;
-        Add16b _add16b;
+#if defined(SYNET_SIMD_LIBRARY_ENABLE)
+        Simd::SynetAdd16b _add16b;
+#endif
     };
 }

--- a/src/Synet/Utils/Add.h
+++ b/src/Synet/Utils/Add.h
@@ -28,63 +28,6 @@
 
 namespace Synet
 {
-    class Add16b
-    {
-    public:
-        Add16b()
-            : _context(NULL)
-        {
-        }
-
-        virtual ~Add16b()
-        {
-            Clear();
-        }
-
-        SYNET_INLINE void Init(const Shape & aShape, TensorType aType, const Shape& bShape, TensorType bType, TensorType dstType, TensorFormat format)
-        {
-#ifdef SYNET_SIMD_LIBRARY_ENABLE
-            if (_aShape != aShape || _bShape != bShape)
-            {
-                Clear();
-                _aShape = aShape, _bShape = aShape;
-                _context = ::SimdSynetAdd16bInit(_aShape.data(), _aShape.size(), (SimdTensorDataType)aType, 
-                    _bShape.data(), _bShape.size(), (SimdTensorDataType)bType,
-                    (SimdTensorDataType)dstType, (SimdTensorFormatType)format);
-            }
-#endif
-        }
-
-        SYNET_INLINE bool Enable() const
-        {
-            return _context != NULL;
-        }
-
-        SYNET_INLINE void Forward(const uint8_t* a, const uint8_t* b, uint8_t* dst)
-        {
-#ifdef SYNET_SIMD_LIBRARY_ENABLE
-            if (_context)
-                ::SimdSynetAdd16bForward(_context, a, b, dst);
-#endif
-        }
-
-        SYNET_INLINE void Clear()
-        {
-#ifdef SYNET_SIMD_LIBRARY_ENABLE
-            if (_context)
-                ::SimdRelease(_context), _context = NULL;
-            _aShape.clear();
-            _bShape.clear();
-#endif
-        }
-
-    private:
-        void* _context;
-        Shape _aShape, _bShape;
-    };
-
-    //-------------------------------------------------------------------------------------------------
-
     class QuantizedAdd
     {
     public:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace `Synet::Add16b` with the Simd C++ wrapper `Simd::SynetAdd16b` (`Simd/SimdSynet.hpp`) in `AddLayer`.
- Delete class `Synet::Add16b`. `src/Synet/Utils/Add.h` is kept because it still contains `Synet::QuantizedAdd`, so VS2022 project files are unchanged.
- Update the `3rd/Simd` submodule on `dev` so `Simd::SynetAdd16b` is available.

## Test plan
- [x] Build Synet with SIMD enabled (`SYNET_SIMD_LIBRARY_ENABLE`). `AddLayer.cpp` and `QuantizedAddLayer.cpp` compiled; `libSynet.so` linked successfully.
- [ ] Confirm `AddLayer` still uses the 16-bit add path when input shapes are equal (BF16/FP32).
- [x] Confirm `QuantizedAdd` / `QuantizedAddLayer` still compile after removing `Add16b`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f62d872-16cf-438d-8df6-c074b3f1c804?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f62d872-16cf-438d-8df6-c074b3f1c804&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

