### PR TITLE
*refactoring of ConvertInstanceNormalizationNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertIdentityNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInitializer.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInput.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInstanceNormalizationNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLessNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLessOrEqualNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -153,6 +153,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInput.cpp">
       <Filter>OnnxRuntime\I</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInstanceNormalizationNode.cpp">
+      <Filter>OnnxRuntime\I</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertConcatNode.cpp">
       <Filter>OnnxRuntime\C</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -103,6 +103,8 @@ namespace Synet
 
     bool ConvertInput(const onnx::ValueInfoProto& input, bool trans, Synet::NetworkParam& network, Renames& renames);
 
+    bool ConvertInstanceNormalizationNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer);
+
     bool ConvertLessNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertLessOrEqualNode(const onnx::NodeProto& node, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertInstanceNormalizationNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertInstanceNormalizationNode.cpp
@@ -1,0 +1,64 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertInstanceNormalizationNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 3))
+            return false;
+        layer.type() = Synet::LayerTypeNormalize;
+        layer.normalize().version() = 3;
+        if (!ConvertAtrributeFloat(node, "epsilon", layer.normalize().eps()))
+            return false;
+        layer.weight().resize(2);
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src1 == NULL)
+            return false;
+        if (src1->type() != LayerTypeConst)
+            SYNET_ERROR("InstanceNormalization src[1] must be Const type!");
+        layer.weight()[0] = src1->weight()[0];
+        const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
+        if (src2 == NULL)
+            return false;
+        if (src2->type() != LayerTypeConst)
+            SYNET_ERROR("InstanceNormalization src[2] must be Const type!");
+        layer.weight()[1] = src2->weight()[0];
+        layer.src().resize(1);
+        if (trans && !PermutedToNchw(layers, layer.src(), false, false, false))
+        {
+            layer.normalize().axis() = -1;
+        }
+        else
+            layer.normalize().axis() = 1;
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/ConvertInstanceNormalizationNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertInstanceNormalizationNode.cpp
@@ -51,7 +51,9 @@ namespace Synet
             SYNET_ERROR("InstanceNormalization src[2] must be Const type!");
         layer.weight()[1] = src2->weight()[0];
         layer.src().resize(1);
-        if (trans && !PermutedToNchw(layers, layer.src(), false, false, false))
+        // PermutedToNchw is protected on SynetUtils; expose it for this free function.
+        struct Utils : SynetUtils { using SynetUtils::PermutedToNchw; };
+        if (trans && !Utils::PermutedToNchw(layers, layer.src(), false, false, false))
         {
             layer.normalize().axis() = -1;
         }

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,33 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertInstanceNormalizationNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 3))
-                return false;
-            layer.type() = Synet::LayerTypeNormalize;
-            layer.normalize().version() = 3;
-            if (!ConvertAtrributeFloat(node, "epsilon", layer.normalize().eps()))
-                return false;
-            layer.weight().resize(2);
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src1 == NULL || src1->type() != LayerTypeConst)
-                return false;
-            layer.weight()[0] = src1->weight()[0];
-            const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
-            if (src2 == NULL || src2->type() != LayerTypeConst)
-                return false;
-            layer.weight()[1] = src2->weight()[0];
-            layer.src().resize(1);
-            if (trans && !PermutedToNchw(layers, layer.src(), false, false, false))
-            {
-                layer.normalize().axis() = -1;
-            }
-            else
-                layer.normalize().axis() = 1;
-            return true;
-        }
-
         bool ConvertLayerNormalizationNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer)
         {
             if (!CheckSourceNumber(layer, 3))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertInstanceNormalizationNode` out of `OnnxRuntime.h` into a dedicated `ConvertInstanceNormalizationNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.
- `CheckSourceNumber`, `GetLayer`, and `ConvertAtrributeFloat` already report their own errors. Added `SYNET_ERROR` when `src[1]` or `src[2]` is not `LayerTypeConst`.
- `PermutedToNchw` is protected on `SynetUtils`, so the free function exposes it locally and keeps the original NHWC vs NCHW axis selection.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original body plus Const-type error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertInstanceNormalizationNode.cpp` (alphabetically, `OnnxRuntime\I` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertInstanceNormalizationNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined.
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` and `3rd/bin` ONNX/protobuf headers succeeds and exports `Synet::ConvertInstanceNormalizationNode`.
- [x] Runtime checks against the compiled converter: NCHW axis 1, NHWC axis -1, NCHW permute keeps axis 1, non-const `src[1]` fails, wrong source count fails.
- [ ] Build full `CvtOnnx` / VS2022 solution (not run here).
- [ ] Confirm InstanceNormalization ONNX models still convert end-to-end.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab6a15f6-7dc6-4418-80b9-efb96cf8c780?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab6a15f6-7dc6-4418-80b9-efb96cf8c780&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

