### PR TITLE
*refactoring of ConvertLayerNormalizationNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -63,6 +63,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInitializer.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInput.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertInstanceNormalizationNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLayerNormalizationNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLessNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLessOrEqualNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertConcatNode.cpp">
       <Filter>OnnxRuntime\C</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLayerNormalizationNode.cpp">
+      <Filter>OnnxRuntime\L</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLessNode.cpp">
       <Filter>OnnxRuntime\L</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -105,6 +105,8 @@ namespace Synet
 
     bool ConvertInstanceNormalizationNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer);
 
+    bool ConvertLayerNormalizationNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer);
+
     bool ConvertLessNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertLessOrEqualNode(const onnx::NodeProto& node, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertLayerNormalizationNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertLayerNormalizationNode.cpp
@@ -1,0 +1,76 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertLayerNormalizationNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 3))
+            return false;
+        layer.type() = Synet::LayerTypeNormalize;
+        layer.normalize().version() = 3;
+        if (!ConvertAtrributeFloat(node, "epsilon", layer.normalize().eps()))
+            return false;
+        layer.weight().resize(2);
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src1 == NULL)
+            return false;
+        if (src1->type() != LayerTypeConst)
+            SYNET_ERROR("LayerNormalization src[1] must be Const type!");
+        layer.weight()[0] = src1->weight()[0];
+        const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
+        if (src2 == NULL)
+            return false;
+        if (src2->type() != LayerTypeConst)
+            SYNET_ERROR("LayerNormalization src[2] must be Const type!");
+        layer.weight()[1] = src2->weight()[0];
+        layer.src().resize(1);
+        if (GetAtrribute(node, "axis"))
+        {
+            if (!ConvertAtrributeInt(node, "axis", layer.normalize().axis()))
+                return false;
+            if (layer.normalize().axis() == -1)
+                layer.normalize().version() = 2;
+        }
+        else
+        {
+            // PermutedToNchw is protected on SynetUtils; expose it for this free function.
+            struct Utils : SynetUtils { using SynetUtils::PermutedToNchw; };
+            if (trans && !Utils::PermutedToNchw(layers, layer.src(), false, false, false))
+            {
+                layer.normalize().axis() = -1;
+            }
+            else
+                layer.normalize().axis() = 1;
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,43 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertLayerNormalizationNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 3))
-                return false;
-            layer.type() = Synet::LayerTypeNormalize;
-            layer.normalize().version() = 3;
-            if (!ConvertAtrributeFloat(node, "epsilon", layer.normalize().eps()))
-                return false;
-            layer.weight().resize(2);
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src1 == NULL || src1->type() != LayerTypeConst)
-                return false;
-            layer.weight()[0] = src1->weight()[0];
-            const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
-            if (src2 == NULL || src2->type() != LayerTypeConst)
-                return false;
-            layer.weight()[1] = src2->weight()[0];
-            layer.src().resize(1);
-            if (GetAtrribute(node, "axis"))
-            {
-                if (!ConvertAtrributeInt(node, "axis", layer.normalize().axis()))
-                    return false;
-                if(layer.normalize().axis() == -1)
-                    layer.normalize().version() = 2;
-            }
-            else
-            {
-                if (trans && !PermutedToNchw(layers, layer.src(), false, false, false))
-                {
-                    layer.normalize().axis() = -1;
-                }
-                else
-                    layer.normalize().axis() = 1;
-            }
-            return true;
-        }
-
         bool ConvertLeakyReluNode(const onnx::NodeProto& node, LayerParam& layer)
         {
             layer.type() = Synet::LayerTypeRelu;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertLayerNormalizationNode` out of `OnnxRuntime.h` into a dedicated `ConvertLayerNormalizationNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.
- `CheckSourceNumber`, `GetLayer`, `ConvertAtrributeFloat`, and `ConvertAtrributeInt` already report their own errors. Added `SYNET_ERROR` when `src[1]` or `src[2]` is not `LayerTypeConst`.
- `PermutedToNchw` is protected on `SynetUtils`, so the free function exposes it locally and keeps the original NHWC vs NCHW axis selection when the `axis` attribute is absent. When `axis` is `-1`, `normalize.version` remains `2`.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original body plus Const-type error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertLayerNormalizationNode.cpp` (alphabetically, `OnnxRuntime\L` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertLayerNormalizationNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined.
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` succeeds and exports `Synet::ConvertLayerNormalizationNode`.
- [x] Runtime checks against the compiled converter: wrong source count, non-const `src[1]`/`src[2]`, missing `epsilon`, explicit `axis=-1` (version 2), explicit `axis=1` (version 3), NCHW default axis 1, NHWC default axis -1, NCHW permute keeps axis 1.
- [ ] Build full `CvtOnnx` / VS2022 solution (not run here; ONNX Runtime submodule is private).
- [ ] Confirm LayerNormalization ONNX models still convert end-to-end.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-219b4bca-d902-4925-bcec-09a01f2ad332?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-219b4bca-d902-4925-bcec-09a01f2ad332&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

