### PR TITLE
*refactoring of ConvertLogSoftmaxNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -68,6 +68,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLessNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLessOrEqualNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogSoftmaxNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertNonMaxSuppressionNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPreluNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -174,6 +174,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogNode.cpp">
       <Filter>OnnxRuntime\L</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogSoftmaxNode.cpp">
+      <Filter>OnnxRuntime\L</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp">
       <Filter>OnnxRuntime\M</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -115,6 +115,8 @@ namespace Synet
 
     bool ConvertLogNode(const onnx::NodeProto& node, LayerParam& layer);
 
+    bool ConvertLogSoftmaxNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const Bytes& original, LayerParam& layer);
+
     bool ConvertMulNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, const OnnxParam& onnxParam, LayerParam& layer);
 
     bool ConvertNonMaxSuppressionNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& bin, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertLogSoftmaxNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertLogSoftmaxNode.cpp
@@ -1,0 +1,46 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertLogSoftmaxNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const Bytes& original, LayerParam& layer)
+    {
+        layer.type() = Synet::LayerTypeSoftmax;
+        if (!ConvertAtrributeInt(node, "axis", layer.softmax().axis()))
+            return false;
+        // PermutedToNchw is protected on SynetUtils; expose it for this free function.
+        struct Utils : SynetUtils { using SynetUtils::PermutedToNchw; };
+        if (trans && !Utils::PermutedToNchw(layers, layer.src(), false, false, false))
+            SYNET_ERROR("This layer can work only in NCHW format!");
+        layer.softmax().log() = true;
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,20 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertLogSoftmaxNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const Bytes& original, LayerParam& layer)
-        {
-            layer.type() = Synet::LayerTypeSoftmax;
-            if (!ConvertAtrributeInt(node, "axis", layer.softmax().axis()))
-                return false;
-            if (trans && !PermutedToNchw(layers, layer.src(), false, false, false))
-            {
-                CPL_LOG_SS(Error, "This layer can work only in NCHW format!");
-                return false;
-            }
-            layer.softmax().log() = true;
-            return true;
-        }
-
         bool ConvertLstmNode(const onnx::NodeProto& node, LayerParams& layers, LayerParam& layer)
         {
             layer.type() = Synet::LayerTypeLstm;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertLogSoftmaxNode` out of `OnnxRuntime.h` into a dedicated `ConvertLogSoftmaxNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.
- `ConvertAtrributeInt` already reports missing or wrong-type `axis` errors. The NCHW-only layout failure now uses `SYNET_ERROR` so it goes through the same conversion-error path.

## Test plan
- [x] Confirm the extracted function keeps the original Softmax + `log` + `axis` + NCHW-only behavior from `origin/dev`.
- [x] Validate `CvtOnnx.vcxproj` / `CvtOnnx.vcxproj.filters` XML and `ConvertLogSoftmaxNode.cpp` registration under `OnnxRuntime\L`.
- [x] Compile `ConvertLogSoftmaxNode.cpp` and run a caller that checks success (`LayerTypeSoftmax`, `log=true`, axis) and conversion errors (missing/wrong `axis`, NHWC layout).
- [ ] Full `CvtOnnx` / VS2022 build is not available here (ONNX Runtime submodule is private and not initialized).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c867cbb-1359-4a91-b014-1590e40669d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c867cbb-1359-4a91-b014-1590e40669d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

