### PR TITLE
*refactoring of ConvertLstmNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -69,6 +69,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLessOrEqualNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogSoftmaxNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLstmNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertNonMaxSuppressionNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPreluNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -177,6 +177,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogSoftmaxNode.cpp">
       <Filter>OnnxRuntime\L</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLstmNode.cpp">
+      <Filter>OnnxRuntime\L</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp">
       <Filter>OnnxRuntime\M</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -117,6 +117,8 @@ namespace Synet
 
     bool ConvertLogSoftmaxNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const Bytes& original, LayerParam& layer);
 
+    bool ConvertLstmNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);
+
     bool ConvertMulNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, const OnnxParam& onnxParam, LayerParam& layer);
 
     bool ConvertNonMaxSuppressionNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& bin, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertLstmNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertLstmNode.cpp
@@ -1,0 +1,75 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertLstmNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
+    {
+        layer.type() = Synet::LayerTypeLstm;
+        if (!ConvertAtrributeInt(node, "hidden_size", layer.lstm().hiddenSize()))
+            return false;
+        String direction;
+        if (!ConvertAtrributeString(node, "direction", direction))
+            return false;
+        if (direction == "forward")
+            layer.lstm().direction() = LstmDirectionTypeForward;
+        else if (direction == "reverse")
+            layer.lstm().direction() = LstmDirectionTypeReverse;
+        else if (direction == "bidirectional")
+            layer.lstm().direction() = LstmDirectionTypeBidirectional;
+        else
+            SYNET_ERROR("Unsupported LSTM direction '" << direction << "' !");
+        if (!CheckSourceNumber(layer, 6))
+            return false;
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src1 == NULL)
+            return false;
+        if (src1->type() != LayerTypeConst)
+            SYNET_ERROR("LSTM src[1] must be Const type!");
+        const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
+        if (src2 == NULL)
+            return false;
+        if (src2->type() != LayerTypeConst)
+            SYNET_ERROR("LSTM src[2] must be Const type!");
+        const LayerParam* src3 = GetLayer(layers, layer.src()[3]);
+        if (src3 == NULL)
+            return false;
+        if (src3->type() != LayerTypeConst)
+            SYNET_ERROR("LSTM src[3] must be Const type!");
+        layer.weight().resize(3);
+        layer.weight()[0] = src1->weight()[0];
+        layer.weight()[1] = src2->weight()[0];
+        layer.weight()[2] = src3->weight()[0];
+        layer.src().erase(layer.src().begin() + 1, layer.src().begin() + 4);
+        layer.dst().resize(1);
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,42 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertLstmNode(const onnx::NodeProto& node, LayerParams& layers, LayerParam& layer)
-        {
-            layer.type() = Synet::LayerTypeLstm;
-            if (!ConvertAtrributeInt(node, "hidden_size", layer.lstm().hiddenSize()))
-                return false;
-            String direction;
-            if (!ConvertAtrributeString(node, "direction", direction))
-                return false;
-            if (direction == "forward")
-                layer.lstm().direction() = LstmDirectionTypeForward;
-            else if (direction == "reverse")
-                layer.lstm().direction() = LstmDirectionTypeReverse;
-            else if (direction == "bidirectional")
-                layer.lstm().direction() = LstmDirectionTypeBidirectional;
-            else
-                return false;
-            if (!CheckSourceNumber(layer, 6))
-                return false;
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src1 == NULL || src1->type() != LayerTypeConst)
-                return false;
-            const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
-            if (src2 == NULL || src2->type() != LayerTypeConst)
-                return false;
-            const LayerParam* src3 = GetLayer(layers, layer.src()[3]);
-            if (src3 == NULL || src3->type() != LayerTypeConst)
-                return false;
-            layer.weight().resize(3);
-            layer.weight()[0] = src1->weight()[0];
-            layer.weight()[1] = src2->weight()[0];           
-            layer.weight()[2] = src3->weight()[0];
-            layer.src().erase(layer.src().begin() + 1, layer.src().begin() + 4);
-            layer.dst().resize(1);
-            return true;
-        }
-
         bool ConvertMatMulNode(const onnx::NodeProto& node, bool trans, LayerParams& layers, LayerParam& layer, TensorFormatMap *tensorFormatMap)
         {
             if (!CheckSourceNumber(layer, 2))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertLstmNode` out of `OnnxRuntime.h` into a dedicated `ConvertLstmNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.
- `ConvertAtrributeInt`, `ConvertAtrributeString`, `CheckSourceNumber`, and `GetLayer` already report their own errors. Added `SYNET_ERROR` for unsupported `direction` values and when `src[1]`, `src[2]`, or `src[3]` is not `LayerTypeConst`.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original body plus error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertLstmNode.cpp` (alphabetically after `ConvertLogSoftmaxNode.cpp`, `OnnxRuntime\L` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertLstmNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (0 symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` succeeds and exports `Synet::ConvertLstmNode`.
- [x] Runtime checks against the compiled converter: forward/reverse/bidirectional success (hidden size, W/R/B weights, src becomes `x,h,c`, dst resized to 1); errors for unsupported direction, missing `hidden_size`/`direction`, wrong source count, and non-const `src[1]`/`src[2]`/`src[3]`.
- [ ] Full `CvtOnnx` / VS2022 build is not available here (ONNX Runtime submodule is private and not initialized).
- [ ] Confirm LSTM ONNX models still convert end-to-end.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd04a0c5-0a4f-407c-9724-ee3680224734?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd04a0c5-0a4f-407c-9724-ee3680224734&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

