### PR TITLE
*refactoring of ConvertMatMulNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogSoftmaxNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLstmNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMatMulNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertNonMaxSuppressionNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPreluNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -180,6 +180,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLstmNode.cpp">
       <Filter>OnnxRuntime\L</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMatMulNode.cpp">
+      <Filter>OnnxRuntime\M</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp">
       <Filter>OnnxRuntime\M</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -119,6 +119,8 @@ namespace Synet
 
     bool ConvertLstmNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);
 
+    bool ConvertMatMulNode(const onnx::NodeProto& node, bool trans, LayerParams& layers, LayerParam& layer, TensorFormatMap* tensorFormatMap);
+
     bool ConvertMulNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, const OnnxParam& onnxParam, LayerParam& layer);
 
     bool ConvertNonMaxSuppressionNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& bin, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertMatMulNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertMatMulNode.cpp
@@ -1,0 +1,87 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+
+namespace Synet
+{
+    bool ConvertMatMulNode(const onnx::NodeProto& node, bool trans, LayerParams& layers, LayerParam& layer, TensorFormatMap* tensorFormatMap)
+    {
+        if (!CheckSourceNumber(layer, 2))
+            return false;
+        layer.type() = Synet::LayerTypeInnerProduct;
+        int transB = false;
+        layer.weight().resize(layer.src().size() - 1);
+        layer.innerProduct().biasTerm() = false;
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src1 == NULL)
+            return false;
+        if (src1->type() == LayerTypeConst)
+        {
+            if (src1->weight().empty())
+                SYNET_ERROR("MatMul src[1] Const layer has no weight!");
+            layer.weight()[0] = src1->weight()[0];
+        }
+        else if (src1->type() == LayerTypePermute)
+        {
+            if (!CheckSourceNumber(*src1, 1))
+                return false;
+            const LayerParam* src10 = GetLayer(layers, src1->src()[0]);
+            if (src10 == NULL)
+                return false;
+            if (src10->type() == LayerTypeConst)
+            {
+                if (src10->weight().empty())
+                    SYNET_ERROR("MatMul permute src[1] Const source has no weight!");
+                transB = true;
+                layer.weight() = src10->weight();
+                layers.erase(layers.begin() + (src1 - layers.data()));
+            }
+        }
+        Shape weight = layer.weight()[0].dim();
+        layer.innerProduct().transposeB() = !transB;
+        if (weight.empty())
+        {
+            layer.weight().clear();
+            layer.innerProduct().outputNum() = 0;
+            layer.innerProduct().axis() = -1;
+        }
+        else
+        {
+            //if (!CheckSignificantDims(weight, 2, "MatMul weight"))
+            //    return false;
+            if (weight.size() > 2)
+                layer.innerProduct().axis() = weight.size() - 1;
+            layer.innerProduct().outputNum() = (uint32_t)(transB ? weight[weight.size() - 2] : weight[weight.size() - 1]);
+            layer.src().resize(1);
+            if (trans && CurrentTensorFormat(layers, layer.src(), true, false, true, tensorFormatMap) == TensorFormatNhwc)
+                SYNET_ERROR("Can 't convert MatMul node for NHWC format!");
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,57 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertMatMulNode(const onnx::NodeProto& node, bool trans, LayerParams& layers, LayerParam& layer, TensorFormatMap *tensorFormatMap)
-        {
-            if (!CheckSourceNumber(layer, 2))
-                return false;
-            layer.type() = Synet::LayerTypeInnerProduct;
-            int transB = false;
-            layer.weight().resize(layer.src().size() - 1);
-            layer.innerProduct().biasTerm() = false;
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src1 == NULL)
-                return false;
-            if (src1->type() == LayerTypeConst)
-            {
-                layer.weight()[0] = src1->weight()[0];
-            }
-            else if (src1->type() == LayerTypePermute)
-            {
-                if (!CheckSourceNumber(*src1, 1))
-                    return false;
-                const LayerParam* src10 = GetLayer(layers, src1->src()[0]);
-                if (src10 == NULL) 
-                    return false;
-                if (src10->type() == LayerTypeConst)
-                {
-                    transB = true;
-                    layer.weight() = src10->weight();
-                    layers.erase(layers.begin() + (src1 - layers.data()));
-                }
-            }
-            Shape weight = layer.weight()[0].dim();
-            layer.innerProduct().transposeB() = !transB;
-            if (weight.empty())
-            {
-                layer.weight().clear();
-                layer.innerProduct().outputNum() = 0;
-                layer.innerProduct().axis() = -1;
-            }
-            else
-            {
-                //if (!CheckSignificantDims(weight, 2, "MatMul weight"))
-                //    return false;
-                if(weight.size() > 2)
-                    layer.innerProduct().axis() = weight.size() - 1;
-                layer.innerProduct().outputNum() = (uint32_t)(transB ? weight[weight.size() - 2] : weight[weight.size() - 1]);
-                layer.src().resize(1);
-                if (trans && CurrentTensorFormat(layers, layer.src(), true, false, true, tensorFormatMap) == TensorFormatNhwc)
-                    SYNET_ERROR("Can 't convert MatMul node for NHWC format!");
-            }
-            return true;
-        }
-
         bool ConvertMaxPoolNode(const onnx::NodeProto& node, LayerParam& layer)
         {
             layer.type() = Synet::LayerTypePooling;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertMatMulNode` out of `OnnxRuntime.h` into a dedicated `ConvertMatMulNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.
- `CheckSourceNumber` and `GetLayer` already report their own errors. Kept the existing NHWC format `SYNET_ERROR`. Added `SYNET_ERROR` when a Const weight used by MatMul has no data.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original body plus error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertMatMulNode.cpp` (alphabetically after `ConvertLstmNode.cpp`, `OnnxRuntime\M` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertMatMulNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` succeeds and exports `Synet::ConvertMatMulNode`.
- [x] Runtime checks against the compiled converter: Const weight (2D and 3D), permute-of-Const (`transB`, permute erased), dynamic empty weight, permute-of-non-Const stays dynamic, wrong source count, missing layer, empty Const weight, empty permute Const weight, permute wrong source count, NHWC rejected when `trans`, NHWC allowed when not `trans`.
- [ ] Full `CvtOnnx` / VS2022 build is not available here (ONNX Runtime submodule is private and not initialized).
- [ ] Confirm MatMul ONNX models still convert end-to-end.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2a20a8e-190b-4e4c-bc7d-931499188fe4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2a20a8e-190b-4e4c-bc7d-931499188fe4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

