### PR TITLE
*refactoring of ConvertMaxPoolNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -71,6 +71,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLogSoftmaxNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertLstmNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMatMulNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMaxPoolNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertNonMaxSuppressionNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPreluNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -183,6 +183,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMatMulNode.cpp">
       <Filter>OnnxRuntime\M</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMaxPoolNode.cpp">
+      <Filter>OnnxRuntime\M</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertMulNode.cpp">
       <Filter>OnnxRuntime\M</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -121,6 +121,8 @@ namespace Synet
 
     bool ConvertMatMulNode(const onnx::NodeProto& node, bool trans, LayerParams& layers, LayerParam& layer, TensorFormatMap* tensorFormatMap);
 
+    bool ConvertMaxPoolNode(const onnx::NodeProto& node, LayerParam& layer);
+
     bool ConvertMulNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, const OnnxParam& onnxParam, LayerParam& layer);
 
     bool ConvertNonMaxSuppressionNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& bin, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertMaxPoolNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertMaxPoolNode.cpp
@@ -1,0 +1,56 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertMaxPoolNode(const onnx::NodeProto& node, LayerParam& layer)
+    {
+        layer.type() = Synet::LayerTypePooling;
+        layer.pooling().method() = PoolingMethodTypeMax;
+        if (!ConvertAtrributeInts(node, "kernel_shape", layer.pooling().kernel()))
+            return false;
+        if (!ConvertAtrributeInts(node, "pads", layer.pooling().pad()))
+            return false;
+        if (!ConvertAtrributeInts(node, "strides", layer.pooling().stride()))
+            return false;
+
+        if (GetAtrribute(node, "ceil_mode") == NULL)
+            layer.pooling().roundingType() = RoundingTypeFloor;
+        else
+        {
+            int ceilMode;
+            if (!ConvertAtrributeInt(node, "ceil_mode", ceilMode))
+                return false;
+            layer.pooling().roundingType() = ceilMode ? RoundingTypeCeil : RoundingTypeFloor;
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,29 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertMaxPoolNode(const onnx::NodeProto& node, LayerParam& layer)
-        {
-            layer.type() = Synet::LayerTypePooling;
-            layer.pooling().method() = PoolingMethodTypeMax;
-            if (!ConvertAtrributeInts(node, "kernel_shape", layer.pooling().kernel()))
-                return false;
-            if (!ConvertAtrributeInts(node, "pads", layer.pooling().pad()))
-                return false;
-            if (!ConvertAtrributeInts(node, "strides", layer.pooling().stride()))
-                return false;
-
-            if(GetAtrribute(node, "ceil_mode") == NULL)
-                layer.pooling().roundingType() = RoundingTypeFloor;
-            else
-            {
-                int ceilMode;
-                if (!ConvertAtrributeInt(node, "ceil_mode", ceilMode))
-                    return false;
-                layer.pooling().roundingType() = ceilMode ? RoundingTypeCeil : RoundingTypeFloor;
-            }
-            return true;
-        }
-
         bool ConvertModNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
         {
             if (!CheckSourceNumber(layer, 2))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertMaxPoolNode` out of `OnnxRuntime.h` into a dedicated `ConvertMaxPoolNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.
- `ConvertAtrributeInts` and `ConvertAtrributeInt` already report their own errors, so no extra `SYNET_ERROR` calls were added.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original body, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertMaxPoolNode.cpp` (alphabetically after `ConvertMatMulNode.cpp`, `OnnxRuntime\M` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertMaxPoolNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` succeeds and exports `Synet::ConvertMaxPoolNode`.
- [x] Runtime checks against the compiled converter: kernel/pads/strides mapping, missing `ceil_mode` => Floor, `ceil_mode=0` => Floor, `ceil_mode=1` => Ceil, missing `kernel_shape`/`pads`/`strides` fail, wrong `ceil_mode` type fails.
- [ ] Full `CvtOnnx` / VS2022 build is not available here (ONNX Runtime submodule is private and not initialized).
- [ ] Confirm MaxPool ONNX models still convert end-to-end.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b82fd7a-4fdc-4969-b6b7-b6b6603bdd49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b82fd7a-4fdc-4969-b6b7-b6b6603bdd49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

