### PR TITLE
*refactoring of ConvertTopKNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -90,6 +90,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTopKNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTransposeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\OnnxRuntime.cpp" />
   </ItemGroup>

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -243,6 +243,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp">
       <Filter>OnnxRuntime\T</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTopKNode.cpp">
+      <Filter>OnnxRuntime\T</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTransposeNode.cpp">
       <Filter>OnnxRuntime\T</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -159,6 +159,8 @@ namespace Synet
 
     bool ConvertTileNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer, TensorFormatMap* tensorFormatMap);
 
+    bool ConvertTopKNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);
+
     bool ConvertTransposeNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const OnnxParam& onnxParam, LayerParam& layer, TensorFormatMap* tensorFormatMap);
 }
 

--- a/src/Cvt/OnnxRuntime/ConvertTopKNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertTopKNode.cpp
@@ -1,0 +1,62 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertTopKNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 2))
+            return false;
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src1 == NULL)
+            return false;
+
+        layer.type() = Synet::LayerTypeTopK;
+        if (src1->type() == LayerTypeMeta && src1->meta().type() == MetaTypeConst && src1->meta().alpha().type() == TensorType64i)
+        {
+            layer.topK().k() = src1->meta().alpha().i64()[0];
+            layer.src().resize(1);
+        }
+        if (!ConvertAtrributeInt(node, "axis", layer.topK().axis()))
+            return false;
+        int64_t largest;
+        if (!ConvertAtrributeInt(node, "largest", largest))
+            return false;
+        layer.topK().mode() = largest ? TopKModeMax : TopKModeMin;
+        int64_t sorted;
+        if (!ConvertAtrributeInt(node, "sorted", sorted))
+            return false;
+        layer.topK().sort() = sorted ? TopKSortValue : TopKSortIndex;
+        layer.topK().indexElementType() = TensorType64i;
+
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -660,35 +660,6 @@ namespace Synet
             return true;
         }
 
-        bool ConvertTopKNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 2))
-                return false;
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src1 == NULL)
-                return false;
-
-            layer.type() = Synet::LayerTypeTopK;
-            if (src1->type() == LayerTypeMeta && src1->meta().type() == MetaTypeConst && src1->meta().alpha().type() == TensorType64i)
-            {
-                layer.topK().k() = src1->meta().alpha().i64()[0];
-                layer.src().resize(1);
-            }
-            if (!ConvertAtrributeInt(node, "axis", layer.topK().axis()))
-                return false;
-            int64_t largest;
-            if (!ConvertAtrributeInt(node, "largest", largest))
-                return false;
-            layer.topK().mode() = largest ? TopKModeMax : TopKModeMin;
-            int64_t sorted;
-            if (!ConvertAtrributeInt(node, "sorted", sorted))
-                return false;
-            layer.topK().sort() = sorted ? TopKSortValue : TopKSortIndex;
-            layer.topK().indexElementType() = TensorType64i;
-
-            return true;
-        }
-
         bool ConvertUnsqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
         {
             if (!CheckSourceNumber(layer, 1, 2))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertTopKNode` out of `OnnxRuntime.h` into a dedicated `ConvertTopKNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`.
- `CheckSourceNumber`, `GetLayer`, and `ConvertAtrributeInt` already report their own errors, so no extra `SYNET_ERROR` calls were added.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original body, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertTopKNode.cpp` (alphabetically after `ConvertTileNode.cpp`, `OnnxRuntime\T` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertTopKNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` succeeds and exports `Synet::ConvertTopKNode`.
- [x] Runtime checks: const-K folds to one source and copies `k`; dynamic-K keeps two sources; `largest`/`sorted` map to TopK mode/sort; lookup by dst alias; wrong source count / missing layer / missing or mistyped attributes fail with helper error messages.
- [ ] Full `CvtOnnx` / VS2022 build is not available here (ONNX Runtime submodule is private and not initialized).
- [ ] Confirm TopK ONNX models still convert end-to-end.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02ab2783-7850-45da-8ca1-a853e09f5e4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02ab2783-7850-45da-8ca1-a853e09f5e4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

