### PR TITLE
Rename Test::RegionDecoder to Test::RegionDetection

### DIFF
--- a/prj/vs2022/TestBf16.vcxproj
+++ b/prj/vs2022/TestBf16.vcxproj
@@ -43,7 +43,7 @@
     <ClInclude Include="..\..\src\Test\TestOutputComparer.h" />
     <ClInclude Include="..\..\src\Test\TestParams.h" />
     <ClInclude Include="..\..\src\Test\TestPerformance.h" />
-    <ClInclude Include="..\..\src\Test\TestRegionDecoder.h" />
+    <ClInclude Include="..\..\src\Test\TestRegionDetection.h" />
     <ClInclude Include="..\..\src\Test\TestReport.h" />
     <ClInclude Include="..\..\src\Test\TestSynet.h" />
     <ClInclude Include="..\..\src\Test\TestUtils.h" />

--- a/prj/vs2022/TestInferenceEngine.vcxproj
+++ b/prj/vs2022/TestInferenceEngine.vcxproj
@@ -37,7 +37,7 @@
     <ClInclude Include="..\..\src\Test\TestOutputComparer.h" />
     <ClInclude Include="..\..\src\Test\TestParams.h" />
     <ClInclude Include="..\..\src\Test\TestPerformance.h" />
-    <ClInclude Include="..\..\src\Test\TestRegionDecoder.h" />
+    <ClInclude Include="..\..\src\Test\TestRegionDetection.h" />
     <ClInclude Include="..\..\src\Test\TestReport.h" />
     <ClInclude Include="..\..\src\Test\TestSynet.h" />
     <ClInclude Include="..\..\src\Test\TestUtils.h" />

--- a/prj/vs2022/TestMultiThreads.vcxproj
+++ b/prj/vs2022/TestMultiThreads.vcxproj
@@ -41,7 +41,7 @@
     <ClInclude Include="..\..\src\Test\TestOutputComparer.h" />
     <ClInclude Include="..\..\src\Test\TestParams.h" />
     <ClInclude Include="..\..\src\Test\TestPerformance.h" />
-    <ClInclude Include="..\..\src\Test\TestRegionDecoder.h" />
+    <ClInclude Include="..\..\src\Test\TestRegionDetection.h" />
     <ClInclude Include="..\..\src\Test\TestReport.h" />
     <ClInclude Include="..\..\src\Test\TestUtils.h" />
   </ItemGroup>

--- a/prj/vs2022/TestOnnx.vcxproj
+++ b/prj/vs2022/TestOnnx.vcxproj
@@ -37,7 +37,7 @@
     <ClInclude Include="..\..\src\Test\TestOutputComparer.h" />
     <ClInclude Include="..\..\src\Test\TestParams.h" />
     <ClInclude Include="..\..\src\Test\TestPerformance.h" />
-    <ClInclude Include="..\..\src\Test\TestRegionDecoder.h" />
+    <ClInclude Include="..\..\src\Test\TestRegionDetection.h" />
     <ClInclude Include="..\..\src\Test\TestReport.h" />
     <ClInclude Include="..\..\src\Test\TestSynet.h" />
     <ClInclude Include="..\..\src\Test\TestUtils.h" />

--- a/src/Test/TestMultiThreads.cpp
+++ b/src/Test/TestMultiThreads.cpp
@@ -31,7 +31,7 @@
 #include "TestReport.h"
 #include "TestOptions.h"
 #include "TestParams.h"
-#include "TestRegionDecoder.h"
+#include "TestRegionDetection.h"
 #include "TestOutputComparer.h"
 
 namespace Test
@@ -77,7 +77,7 @@ namespace Test
         bool _trans, _sort, _stopped;
         Floats _lower, _upper;
         size_t _synetMemoryUsage;
-        RegionDecoder _regionDecoder;
+        RegionDetection _regionDetection;
 
         typedef Tensors Output;
         typedef std::vector<Output> Outputs;
@@ -159,7 +159,7 @@ namespace Test
             _lower = _param().lower();
             _upper = _param().upper();
             _synetMemoryUsage = _net.MemoryUsage();
-            _regionDecoder.Init(_net, _param().detection());
+            _regionDetection.Init(_net, _param().detection());
 
             Shape shape = _net.NchwShape();
             if (!(_param().inputType() == "binary" || shape[1] == 1 || shape[1] == 3))
@@ -675,8 +675,8 @@ namespace Test
 
         Regions GetRegions(const Size& size, float threshold, float overlap, size_t thread) const
         {
-            if (_regionDecoder.Enable())
-                return _regionDecoder.GetRegions(_net, size, threshold, overlap, thread);
+            if (_regionDetection.Enable())
+                return _regionDetection.GetRegions(_net, size, threshold, overlap, thread);
             else
                 return _net.GetRegions(size.x, size.y, threshold, overlap, thread);
         }

--- a/src/Test/TestOnnxRuntime.h
+++ b/src/Test/TestOnnxRuntime.h
@@ -27,7 +27,7 @@
 #include "TestCommon.h"
 #include "TestPerformance.h"
 #include "TestNetwork.h"
-#include "TestRegionDecoder.h"
+#include "TestRegionDetection.h"
 
 #if defined(SYNET_ONNXRUNTIME_ENABLE)
 
@@ -207,7 +207,7 @@ namespace Test
             if(!_dynamicOutput)
                 ReshapeOutput();
 
-            _regionDecoder.Init(_inputShapes[0], _outputNameBuffers, param.detection());
+            _regionDetection.Init(_inputShapes[0], _outputNameBuffers, param.detection());
 
             return true;
         }
@@ -268,8 +268,8 @@ namespace Test
 
         virtual Regions GetRegions(const Size & size, float threshold, float overlap) const
         {
-            if (_regionDecoder.Enable())
-                return _regionDecoder.GetRegions(_output, size, threshold, overlap);
+            if (_regionDetection.Enable())
+                return _regionDetection.GetRegions(_output, size, threshold, overlap);
             else
             {
                 Regions regions;
@@ -321,7 +321,7 @@ namespace Test
         size_t _batchSize;
         bool _dynamicOutput;
 
-        RegionDecoder _regionDecoder;
+        RegionDetection _regionDetection;
 
         struct Env
         {

--- a/src/Test/TestOpenVino.h
+++ b/src/Test/TestOpenVino.h
@@ -27,7 +27,7 @@
 #include "TestCommon.h"
 #include "TestPerformance.h"
 #include "TestNetwork.h"
-#include "TestRegionDecoder.h"
+#include "TestRegionDetection.h"
 
 #include <openvino/openvino.hpp>
 
@@ -121,7 +121,7 @@ namespace Test
                     CreateCompiledModelAndInferRequest();
                 GetTensors();
                 StubInfer();
-                _ov->regionDecoder.Init(Shape(_ov->model->input(0).get_shape()), _ov->outputNames, param.detection());
+                _ov->regionDetection.Init(Shape(_ov->model->input(0).get_shape()), _ov->outputNames, param.detection());
             }
             catch (std::exception& e)
             {
@@ -162,8 +162,8 @@ namespace Test
 
         virtual Regions GetRegions(const Size& size, float threshold, float overlap) const
         {
-            if (_ov->regionDecoder.Enable())
-                return _ov->regionDecoder.GetRegions(_output, size, threshold, overlap);
+            if (_ov->regionDetection.Enable())
+                return _ov->regionDetection.GetRegions(_output, size, threshold, overlap);
             else
             {
                 Regions regions;
@@ -206,7 +206,7 @@ namespace Test
             std::vector<ov::Tensor> input, output;
             Strings inputNames, outputNames;
             size_t batchSize;
-            RegionDecoder regionDecoder;
+            RegionDetection regionDetection;
         };
         typedef std::shared_ptr<Ov> OvPtr;
         OvPtr _ov;

--- a/src/Test/TestOutputComparer.h
+++ b/src/Test/TestOutputComparer.h
@@ -26,7 +26,7 @@
 
 #include "TestParams.h"
 #include "TestOptions.h"
-#include "TestRegionDecoder.h"
+#include "TestRegionDetection.h"
 
 #include "Synet/Utils/Difference.h"
 #include "Synet/Utils/DebugPrint.h"
@@ -37,7 +37,7 @@ namespace Test
     {
         const Options & _options;
         const TestParam& _param;
-        RegionDecoder _regionDecoder;
+        RegionDetection _regionDetection;
 
     public:
         typedef Synet::Region<float> Region;
@@ -55,7 +55,7 @@ namespace Test
                 Strings names;
                 for (size_t i = 0; i < dst.size(); ++i)
                     names.push_back(dst[i].Name());
-                _regionDecoder.Init(src, names, _param.detection());
+                _regionDetection.Init(src, names, _param.detection());
             }
         }
 
@@ -69,7 +69,7 @@ namespace Test
                 SYNET_ERROR(failed << std::endl << "Dst count : " << first.size() << " != " << second.size());
             if (_param.output().size() != first.size() && _param.output().size() != 0)
                 SYNET_ERROR(failed << std::endl << "Check output parameter size!" << _param.output().size() << " != " << first.size() << " !");
-            if (_regionDecoder.Enable())
+            if (_regionDetection.Enable())
                 return CompareRegions(first, second, failed);
             for (size_t d = 0; d < first.size(); ++d)
             {
@@ -391,8 +391,8 @@ namespace Test
                 if (_param.output().size() && _param.output()[0].fp32Threshold() != 0.0f)
                     compareThreshold = _param.output()[0].fp32Threshold();
             }
-            Regions rf = _regionDecoder.GetRegions(f, Size(1, 1), _param.detection().confidence(), _options.regionOverlap);
-            Regions rs = _regionDecoder.GetRegions(s, Size(1, 1), _param.detection().confidence(), _options.regionOverlap);
+            Regions rf = _regionDetection.GetRegions(f, Size(1, 1), _param.detection().confidence(), _options.regionOverlap);
+            Regions rs = _regionDetection.GetRegions(s, Size(1, 1), _param.detection().confidence(), _options.regionOverlap);
             SortRegionsByProb(rf);
             SortRegionsByProb(rs);
             size_t n = std::min(rf.size(), rs.size());

--- a/src/Test/TestRegionDetection.h
+++ b/src/Test/TestRegionDetection.h
@@ -30,7 +30,7 @@
 
 namespace Test
 {
-    class RegionDecoder
+    class RegionDetection
     {
         Shape _shape;
         Strings _names;
@@ -61,7 +61,7 @@ namespace Test
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 
-        RegionDecoder()
+        RegionDetection()
             : _enable(false)
         {
         }

--- a/src/Test/TestSynet.h
+++ b/src/Test/TestSynet.h
@@ -27,7 +27,7 @@
 #include "TestCommon.h"
 #include "TestPerformance.h"
 #include "TestNetwork.h"
-#include "TestRegionDecoder.h"
+#include "TestRegionDetection.h"
 
 #include "Synet/Network.h"
 
@@ -100,7 +100,7 @@ namespace Test
                 _lower = param.lower();
                 _upper = param.upper();
                 _synetMemoryUsage = _net.MemoryUsage();
-                _regionDecoder.Init(_net, param.detection());
+                _regionDetection.Init(_net, param.detection());
                 return true;
             }
             return false;
@@ -137,8 +137,8 @@ namespace Test
 
         virtual Regions GetRegions(const Size & size, float threshold, float overlap) const
         {
-            if (_regionDecoder.Enable())
-                return _regionDecoder.GetRegions(_net, size, threshold, overlap, CTX_NUM - 1);
+            if (_regionDetection.Enable())
+                return _regionDetection.GetRegions(_net, size, threshold, overlap, CTX_NUM - 1);
             else
                 return _net.GetRegions(size.x, size.y, threshold, overlap, CTX_NUM - 1);
         }
@@ -154,7 +154,7 @@ namespace Test
         bool _trans, _sort;
         Floats _lower, _upper;
         size_t _synetMemoryUsage;
-        RegionDecoder _regionDecoder;
+        RegionDetection _regionDetection;
         const int CTX_NUM = 1;
 
         bool Load(const String & model, const String & weight, const Options& options)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rename the test-side region helper from `Test::RegionDecoder` to `Test::RegionDetection`.

This continues the recent `Test::RegionDecoder` refactoring on `dev`. The Synet framework decoder `Synet::RegionDecoder` is unchanged.

## Changes
- Rename class `Test::RegionDecoder` to `Test::RegionDetection`
- Rename header `src/Test/TestRegionDecoder.h` to `src/Test/TestRegionDetection.h`
- Update includes, member names, and Visual Studio project files for TestOnnx, TestBf16, TestInferenceEngine, and TestMultiThreads

## Test plan
- [x] Rebuild CPU test targets that include the renamed class
- [x] Confirm no remaining `Test::RegionDecoder` references
- [x] Confirm `Test::RegionDetection` symbols are present in rebuilt objects

## Test results
Rebuilt successfully after the rename:
- `test_bf16`
- `test_multi_threads`
- `test_optimizer`
- `test_quantization`
- `test_performance_difference`

`TestOnnx` and `TestInferenceEngine` were updated in the Visual Studio projects and headers, but those binaries were not rebuilt here because they require the private OpenVINO / ONNX Runtime submodules.

Object files contain `Test::RegionDetection::Init` / `GetRegions`. The only remaining `RegionDecoder` class is `Synet::RegionDecoder`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac15509d-8a98-4a14-818d-8abaf8f126a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac15509d-8a98-4a14-818d-8abaf8f126a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

