### PR TITLE
-remove template parameter T of class Synet::Tensor.

### DIFF
--- a/src/Cvt/Common/SynetUtils.h
+++ b/src/Cvt/Common/SynetUtils.h
@@ -433,7 +433,7 @@ namespace Synet
         case LayerTypeQuantizedConvolution:
         {
             shape = Shape({ shape[2], shape[3], shape[1], shape[0] });
-            Tensor<float> dst((uint8_t*)pDst, weight.size(), weight.type(), shape, weight.format());
+            Tensor dst((uint8_t*)pDst, weight.size(), weight.type(), shape, weight.format());
             for (size_t o = 0; o < shape[3]; ++o)
                 for (size_t i = 0; i < shape[2]; ++i)
                     for (size_t y = 0; y < shape[0]; ++y)
@@ -444,7 +444,7 @@ namespace Synet
         case LayerTypeDeconvolution:
         {
             shape = Shape({ shape[0], shape[2], shape[3], shape[1] });
-            Tensor<float> dst((uint8_t*)pDst, weight.size(), TensorType32f, shape, weight.format());
+            Tensor dst((uint8_t*)pDst, weight.size(), TensorType32f, shape, weight.format());
             for (size_t i = 0; i < shape[0]; ++i)
                 for (size_t c = 0; c < shape[3]; ++c)
                     for (size_t y = 0; y < shape[1]; ++y)
@@ -635,7 +635,7 @@ namespace Synet
     class SynetUtils
     {
     protected:
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef std::map<String, bool> PermuteMap;
 

--- a/src/Cvt/InferenceEngine/InferenceEngine.h
+++ b/src/Cvt/InferenceEngine/InferenceEngine.h
@@ -119,7 +119,7 @@ namespace Synet
     private:
 
         typedef std::vector<Synet::LayerParam> LayerParams;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
 
         typedef std::vector<float> Vector;

--- a/src/Synet/Decoders/Alpha.h
+++ b/src/Synet/Decoders/Alpha.h
@@ -42,7 +42,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/Anchor.h
+++ b/src/Synet/Decoders/Anchor.h
@@ -48,7 +48,7 @@ namespace Synet
 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/DetOut.h
+++ b/src/Synet/Decoders/DetOut.h
@@ -33,7 +33,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef Synet::Network Net;
 
         DetOutDecoder()

--- a/src/Synet/Decoders/Detection.h
+++ b/src/Synet/Decoders/Detection.h
@@ -93,7 +93,7 @@ namespace Synet
     public:
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/Iim.h
+++ b/src/Synet/Decoders/Iim.h
@@ -42,7 +42,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/Nanodet.h
+++ b/src/Synet/Decoders/Nanodet.h
@@ -41,7 +41,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/Region.h
+++ b/src/Synet/Decoders/Region.h
@@ -34,7 +34,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/Rtdetr.h
+++ b/src/Synet/Decoders/Rtdetr.h
@@ -33,7 +33,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/RtdetrV2.h
+++ b/src/Synet/Decoders/RtdetrV2.h
@@ -38,7 +38,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/Scrfd.h
+++ b/src/Synet/Decoders/Scrfd.h
@@ -41,7 +41,7 @@ namespace Synet
     public:
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/ScrfdV2.h
+++ b/src/Synet/Decoders/ScrfdV2.h
@@ -38,7 +38,7 @@ namespace Synet
     public:
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/Ssd.h
+++ b/src/Synet/Decoders/Ssd.h
@@ -38,7 +38,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/Ultraface.h
+++ b/src/Synet/Decoders/Ultraface.h
@@ -38,7 +38,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/Yolo.h
+++ b/src/Synet/Decoders/Yolo.h
@@ -33,7 +33,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/YoloV11.h
+++ b/src/Synet/Decoders/YoloV11.h
@@ -39,7 +39,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/YoloV5.h
+++ b/src/Synet/Decoders/YoloV5.h
@@ -39,7 +39,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/YoloV7.h
+++ b/src/Synet/Decoders/YoloV7.h
@@ -33,7 +33,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Decoders/YoloV8.h
+++ b/src/Synet/Decoders/YoloV8.h
@@ -33,7 +33,7 @@ namespace Synet
     public: 
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Network Net;
 

--- a/src/Synet/Layer.h
+++ b/src/Synet/Layer.h
@@ -36,7 +36,7 @@ namespace Synet
     class Layer
     {
     public:
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Tensor* TensorPtr;
         typedef std::vector<TensorPtr> TensorPtrs;
@@ -139,19 +139,19 @@ namespace Synet
 
         static float * Buf32f(const TensorPtrs& buf, size_t idx)
         {
-            Synet::Tensor<float>* b = buf[TensorType32f * BUFFER_COUNT + idx];
+            Synet::Tensor* b = buf[TensorType32f * BUFFER_COUNT + idx];
             return b->Data<float>();
         }
 
         static int32_t * Buf32i(const TensorPtrs& buf, size_t idx)
         {
-            Synet::Tensor<float>* b = buf[TensorType32i * BUFFER_COUNT + idx];
+            Synet::Tensor* b = buf[TensorType32i * BUFFER_COUNT + idx];
             return b->Data<int32_t>();
         }
 
         static uint8_t* Buf8u(const TensorPtrs& buf, size_t idx)
         {
-            Synet::Tensor<float>* b = buf[TensorType8u * BUFFER_COUNT + idx];
+            Synet::Tensor* b = buf[TensorType8u * BUFFER_COUNT + idx];
             return b->Data<uint8_t>();
         }
 

--- a/src/Synet/Layers/NonZeroLayer.cpp
+++ b/src/Synet/Layers/NonZeroLayer.cpp
@@ -26,7 +26,7 @@
 
 namespace Synet
 {
-    template<class T> void NonZero(const Tensor<float>& src, Tensor<float>& dst)
+    template<class T> void NonZero(const Tensor& src, Tensor& dst)
     {
         size_t size = src.Size(), nonzeros = 0;
         for (size_t i = 0; i < size; ++i)

--- a/src/Synet/Layers/Quantized/QuantizedScaleLayer.h
+++ b/src/Synet/Layers/Quantized/QuantizedScaleLayer.h
@@ -49,6 +49,6 @@ namespace Synet
         int32_t _srcZero, _dstZero;
         float _srcScale, _dstScale;
         const float * _scale, *_bias;
-        Tensor32f _zero;
+        Tensor _zero;
     };
 }

--- a/src/Synet/Layers/Reshape/MetaLayer.cpp
+++ b/src/Synet/Layers/Reshape/MetaLayer.cpp
@@ -84,7 +84,7 @@ namespace Synet
 
     //-------------------------------------------------------------------------------------------------
 
-    template<class D> static D GetAs(const Synet::Tensor<float>& tensor, size_t offset)
+    template<class D> static D GetAs(const Synet::Tensor& tensor, size_t offset)
     {
         switch (tensor.GetType())
         {
@@ -118,13 +118,13 @@ namespace Synet
 
     //-------------------------------------------------------------------------------------------------
 
-    template<class S, class D> void ReshapeCast(const Synet::Tensor<float>& src, Synet::Tensor<float>& dst)
+    template<class S, class D> void ReshapeCast(const Synet::Tensor& src, Synet::Tensor& dst)
     {
         for (size_t i = 0, n = src.Size(); i < n; ++i)
             dst.Data<D>()[i] = (D)src.Data<S>()[i];
     }
 
-    template<class S> bool ReshapeCast(const Synet::Tensor<float>& src, TensorType type, Synet::Tensor<float>& dst)
+    template<class S> bool ReshapeCast(const Synet::Tensor& src, TensorType type, Synet::Tensor& dst)
     {
         dst.Reshape(type, src.Shape(), src.Format());
         switch (type)
@@ -198,7 +198,7 @@ namespace Synet
 
     //-------------------------------------------------------------------------------------------------
 
-    template<class T> bool ReshapeDiv(const Synet::Tensor<float>& src0, const Synet::Tensor<float>& src1, Synet::Tensor<float>& dst0)
+    template<class T> bool ReshapeDiv(const Synet::Tensor& src0, const Synet::Tensor& src1, Synet::Tensor& dst0)
     {
         dst0.Reshape(Synet::GetTensorType<T>(), src0.Shape(), src0.Format());
         if (src0.Size() == src1.Size())
@@ -348,7 +348,7 @@ namespace Synet
 
     //-------------------------------------------------------------------------------------------------
 
-    template<class T> bool ReshapeMod(const Synet::Tensor<float>& src0, const Synet::Tensor<float>& src1, Synet::Tensor<float>& dst0)
+    template<class T> bool ReshapeMod(const Synet::Tensor& src0, const Synet::Tensor& src1, Synet::Tensor& dst0)
     {
         dst0.Reshape(Synet::GetTensorType<T>(), src0.Shape(), src0.Format());
         if (src0.Size() == src1.Size())
@@ -384,7 +384,7 @@ namespace Synet
 
     //-------------------------------------------------------------------------------------------------
 
-    template<class T> bool ReshapeMul(const Synet::Tensor<float>& src0, const Synet::Tensor<float>& src1, Synet::Tensor<float>& dst0)
+    template<class T> bool ReshapeMul(const Synet::Tensor& src0, const Synet::Tensor& src1, Synet::Tensor& dst0)
     {
         dst0.Reshape(Synet::GetTensorType<T>(), src0.Shape(), src0.Format());
         if (src0.Size() == src1.Size())
@@ -512,7 +512,7 @@ namespace Synet
 
     //-------------------------------------------------------------------------------------------------
 
-    template<class T> void ReshapeRange(const std::vector<Tensor<float>*> & src, const std::vector<Tensor<float>*> dst)
+    template<class T> void ReshapeRange(const std::vector<Tensor*> & src, const std::vector<Tensor*> dst)
     {
         T begin = src[0]->Data<T>()[0];
         T end = src[1]->Data<T>()[0];
@@ -837,7 +837,7 @@ namespace Synet
 
     //-------------------------------------------------------------------------------------------------
 
-    template<class T> bool ReshapeSub(const Synet::Tensor<float>& src0, const Synet::Tensor<float>& src1, Synet::Tensor<float>& dst0)
+    template<class T> bool ReshapeSub(const Synet::Tensor& src0, const Synet::Tensor& src1, Synet::Tensor& dst0)
     {
         dst0.Reshape(Synet::GetTensorType<T>(), src0.Shape(), src0.Format());
         if (src0.Size() == src1.Size())

--- a/src/Synet/Layers/Resize/PadLayer.cpp
+++ b/src/Synet/Layers/Resize/PadLayer.cpp
@@ -26,7 +26,7 @@
 
 namespace Synet
 {
-    template<class T> void PadConstant4(const Tensor<T> & src, const Shape& padB, const Shape& padE, Tensor<T> & dst)
+    template<class T> void PadConstant4(const Tensor & src, const Shape& padB, const Shape& padE, Tensor & dst)
     {
         assert(src.Count() == 4 && padB.size() == 4 && padE.size() == 4 && dst.Count() == 4);
         size_t size = src.Axis(3) * sizeof(T);
@@ -36,8 +36,8 @@ namespace Synet
             {
                 for (size_t i2 = 0; i2 < src.Axis(2); ++i2)
                 {
-                    const T* pSrc = src.template Data<T>(Shp(i0, i1, i2, 0));
-                    T* pDst = dst.template Data<T>(Shp(i0 + padB[0], i1 + padB[1], i2 + padB[2], padB[3]));
+                    const T* pSrc = src.Data<T>(Shp(i0, i1, i2, 0));
+                    T* pDst = dst.Data<T>(Shp(i0 + padB[0], i1 + padB[1], i2 + padB[2], padB[3]));
                     memcpy(pDst, pSrc, size);
                 }
             }
@@ -141,7 +141,7 @@ namespace Synet
         switch (_dims)
         {
         case 4:
-            PadConstant4(*src[0], _padB, _padE, *dst[0]);
+            PadConstant4<float>(*src[0], _padB, _padE, *dst[0]);
             break;
         default:
             assert(0);

--- a/src/Synet/Layers/SoftmaxLayer.cpp
+++ b/src/Synet/Layers/SoftmaxLayer.cpp
@@ -32,7 +32,7 @@ namespace Synet
 #if defined(SYNET_SIMD_LIBRARY_ENABLE) && !defined(SYNET_SIMD_SYNET_DISABLE)
         SimdSynetSoftmax32f(src, outer, count, inner, dst);
 #else
-        Tensor<float> _buffer(TensorType32f, Shp(inner), TensorFormatUnknown);
+        Tensor _buffer(TensorType32f, Shp(inner), TensorFormatUnknown);
         float * buffer = _buffer.Data<float>();
         for (size_t o = 0; o < outer; ++o)
         {
@@ -88,7 +88,7 @@ namespace Synet
 
     void LogSoftmaxLayerForward(const float* src, size_t outer, size_t count, size_t inner, float* dst)
     {
-        Tensor<float> _buffer(TensorType32f, Shp(inner * 2), TensorFormatUnknown);
+        Tensor _buffer(TensorType32f, Shp(inner * 2), TensorFormatUnknown);
         float* max = _buffer.Data<float>(), * sum = max + inner;
         for (size_t o = 0; o < outer; ++o)
         {

--- a/src/Synet/Network.cpp
+++ b/src/Synet/Network.cpp
@@ -683,7 +683,7 @@ namespace Synet
             {
                 for (size_t i = 0; i < _threads[t].tensors.size(); ++i)
                 {
-                    Tensor32f& tn = *_threads[t].tensors[i];
+                    Tensor& tn = *_threads[t].tensors[i];
                     if (tn.Const() && tn.Size() >= 16 && tn.Users() == 1)
                     {
                         const IdSet& ids = _srcIds[tn.Name()];

--- a/src/Synet/Network.h
+++ b/src/Synet/Network.h
@@ -33,7 +33,7 @@ namespace Synet
     {
     public:
         typedef float Type;
-        typedef Synet::Tensor<Type> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor*> TensorPtrs;
         typedef Synet::Layer Layer;
         typedef Layer * LayerPtr;

--- a/src/Synet/Synet.cpp
+++ b/src/Synet/Synet.cpp
@@ -133,30 +133,30 @@ SYNET_API void SynetNetworkForward(void* network)
 
 SYNET_API size_t SynetTensorCount(void* tensor)
 {
-    return ((Synet::Tensor<float>*)tensor)->Count();
+    return ((Synet::Tensor*)tensor)->Count();
 }
 
 SYNET_API size_t SynetTensorAxis(void* tensor, ptrdiff_t axis)
 {
-    return ((Synet::Tensor<float>*)tensor)->Axis(axis);
+    return ((Synet::Tensor*)tensor)->Axis(axis);
 }
 
 SYNET_API SynetTensorFormat SynetTensorFormatGet(void* tensor)
 {
-    return (SynetTensorFormat)((Synet::Tensor<float>*)tensor)->Format();
+    return (SynetTensorFormat)((Synet::Tensor*)tensor)->Format();
 }
 
 SYNET_API SynetTensorType SynetTensorTypeGet(void* tensor)
 {
-    return (SynetTensorType)((Synet::Tensor<float>*)tensor)->GetType();
+    return (SynetTensorType)((Synet::Tensor*)tensor)->GetType();
 }
 
 SYNET_API const char* SynetTensorName(void* tensor)
 {
-    return ((Synet::Tensor<float>*)tensor)->Name().c_str();
+    return ((Synet::Tensor*)tensor)->Name().c_str();
 }
 
 SYNET_API uint8_t* SynetTensorData(void* tensor)
 {
-    return ((Synet::Tensor<float>*)tensor)->RawData();
+    return ((Synet::Tensor*)tensor)->RawData();
 }

--- a/src/Synet/Tensor.h
+++ b/src/Synet/Tensor.h
@@ -33,12 +33,7 @@
 
 namespace Synet
 {
-    struct Unknown
-    {
-    };
-
     template <class T> TensorType GetTensorType();
-    template <> SYNET_INLINE TensorType GetTensorType<Unknown>() { return TensorTypeUnknown; }
     template <> SYNET_INLINE TensorType GetTensorType<float>() { return TensorType32f; }
     template <> SYNET_INLINE TensorType GetTensorType<int32_t>() { return TensorType32i; }
     template <> SYNET_INLINE TensorType GetTensorType<int8_t>() { return TensorType8i; }
@@ -75,11 +70,9 @@ namespace Synet
 
     //-------------------------------------------------------------------------------------------------
 
-    template<class T> class Tensor
+    class Tensor
     {
     public:
-        typedef T Type;
-
         SYNET_INLINE Tensor()
             : _buffer(std::make_shared<Buffer>())
             , _type(TensorTypeUnknown)
@@ -460,7 +453,7 @@ namespace Synet
         {
             if (_buffer->size)
             {
-                Tensor<T> tensor;
+                Tensor tensor;
                 tensor.ShareAs(*this, shape, format);
                 tensor.DebugPrint(os, name, weight, first, last, precision);
             }
@@ -473,7 +466,7 @@ namespace Synet
 
     private:
 
-        template <class U> static void DebugPrint(std::ostream& os, const Tensor<T> & tensor, const String& name, bool weight, size_t first, size_t last, size_t precision)
+        template <class U> static void DebugPrint(std::ostream& os, const Tensor & tensor, const String& name, bool weight, size_t first, size_t last, size_t precision)
         {
             const Synet::Shape& shape = tensor.Shape();
             TensorFormat format = tensor.Format();
@@ -481,12 +474,12 @@ namespace Synet
             {
                 if (weight)
                 {
-                    Tensor<U> trans(tensor.GetType(), Shp(shape[3], shape[2], shape[0], shape[1]), TensorFormatNchw);
+                    Tensor trans(tensor.GetType(), Shp(shape[3], shape[2], shape[0], shape[1]), TensorFormatNchw);
                     for (size_t y = 0; y < shape[0]; ++y)
                         for (size_t x = 0; x < shape[1]; ++x)
                             for (size_t i = 0; i < shape[2]; ++i)
                                 for (size_t o = 0; o < shape[3]; ++o)
-                                    trans.template Data<U>({ o, i, y, x })[0] = tensor.template Data<U>({ y, x, i, o })[0];
+                                    trans.Data<U>({ o, i, y, x })[0] = tensor.Data<U>({ y, x, i, o })[0];
                     std::stringstream ss;
                     ss << name << " HWIO { ";
                     for (size_t i = 0; i < shape.size(); ++i)
@@ -496,12 +489,12 @@ namespace Synet
                 }
                 else
                 {
-                    Tensor<U> trans(tensor.GetType(), Shp(shape[0], shape[3], shape[1], shape[2]), TensorFormatNchw);
+                    Tensor trans(tensor.GetType(), Shp(shape[0], shape[3], shape[1], shape[2]), TensorFormatNchw);
                     for (size_t n = 0; n < shape[0]; ++n)
                         for (size_t c = 0; c < shape[3]; ++c)
                             for (size_t y = 0; y < shape[1]; ++y)
                                 for (size_t x = 0; x < shape[2]; ++x)
-                                    trans.template Data<U>({ n, c, y, x })[0] = tensor.template Data<U>({ n, y, x, c })[0];
+                                    trans.Data<U>({ n, c, y, x })[0] = tensor.Data<U>({ n, y, x, c })[0];
                     std::stringstream ss;
                     ss << name << " NHWC { ";
                     for (size_t i = 0; i < shape.size(); ++i)
@@ -513,11 +506,11 @@ namespace Synet
             }
             else if (shape.size() == 3 && format == TensorFormatNhwc && !weight && shape[0] == 1)
             {
-                Tensor<U> trans(tensor.GetType(), Shp(shape[0], shape[2], shape[1]), TensorFormatNchw);
+                Tensor trans(tensor.GetType(), Shp(shape[0], shape[2], shape[1]), TensorFormatNchw);
                 for (size_t b = 0; b < shape[0]; ++b)
                     for (size_t c = 0; c < shape[2]; ++c)
                         for (size_t s = 0; s < shape[1]; ++s)
-                            trans.template Data<U>({ b, c, s })[0] = tensor.template Data<U>({ b, s, c })[0];
+                            trans.Data<U>({ b, c, s })[0] = tensor.Data<U>({ b, s, c })[0];
                 std::stringstream ss;
                 ss << name << " NHWC { ";
                 for (size_t i = 0; i < shape.size(); ++i)
@@ -528,11 +521,11 @@ namespace Synet
             }
             else if (shape.size() == 3 && format == TensorFormatNhwc && !weight)
             {
-                Tensor<U> trans(tensor.GetType(), Shp(shape[2], shape[0], shape[1]), TensorFormatNchw);
+                Tensor trans(tensor.GetType(), Shp(shape[2], shape[0], shape[1]), TensorFormatNchw);
                 for (size_t c = 0; c < shape[2]; ++c)
                     for (size_t y = 0; y < shape[0]; ++y)
                         for (size_t x = 0; x < shape[1]; ++x)
-                            trans.template Data<U>({ c, y, x })[0] = tensor.template Data<U>({ y, x, c })[0];
+                            trans.Data<U>({ c, y, x })[0] = tensor.Data<U>({ y, x, c })[0];
                 std::stringstream ss;
                 ss << name << " NHWC { ";
                 for (size_t i = 0; i < shape.size(); ++i)
@@ -546,7 +539,7 @@ namespace Synet
                 os << (format == TensorFormatNchw && shape.size() == 4 ? " OIHW" : (format == TensorFormatNhwc && shape.size() == 4 ? " HWIO" : ""));
             else
                 os << (format == TensorFormatNchw ? " NCHW" : (format == TensorFormatNhwc ? " NHWC" : ""));
-            Synet::DebugPrint<U>(os, tensor.template Data<U>(), tensor.Shape(), String(), tensor.Const(), first, last, precision);
+            Synet::DebugPrint<U>(os, tensor.Data<U>(), tensor.Shape(), String(), tensor.Const(), first, last, precision);
         }
 
         template<class U> SYNET_INLINE void Resize(U value)
@@ -579,13 +572,4 @@ namespace Synet
         bool _const;
 
     };
-
-    typedef Tensor<Unknown> TensorAny;
-    typedef Tensor<float> Tensor32f;
-    typedef Tensor<int32_t> Tensor32i;
-    typedef Tensor<int8_t> Tensor8i;
-    typedef Tensor<uint8_t> Tensor8u;
-    typedef Tensor<int64_t> Tensor64i;
-    typedef Tensor<uint64_t> Tensor64u;
-    typedef Tensor<bool> TensorBool;
 }

--- a/src/Synet/Tensor.h
+++ b/src/Synet/Tensor.h
@@ -413,10 +413,10 @@ namespace Synet
             param.shape() = _shape;
             switch (_type)
             {
-            case TensorType32f: param.f32().resize(Data<float>(), Data<float>() + Size()); break;
-            case TensorType32i: param.i32().resize(Data<int32_t>(), Data<int32_t>() + Size()); break;
-            case TensorType64i: param.i64().resize(Data<int64_t>(), Data<int64_t>() + Size()); break;
-            case TensorType64u: param.u64().resize(Data<uint64_t>(), Data<uint64_t>() + Size()); break;
+            case TensorType32f: param.f32().assign(Data<float>(), Data<float>() + Size()); break;
+            case TensorType32i: param.i32().assign(Data<int32_t>(), Data<int32_t>() + Size()); break;
+            case TensorType64i: param.i64().assign(Data<int64_t>(), Data<int64_t>() + Size()); break;
+            case TensorType64u: param.u64().assign(Data<uint64_t>(), Data<uint64_t>() + Size()); break;
             default:
                 SYNET_ERROR("Can't export " << Cpl::ToStr(_type) << " tensor!")
             }

--- a/src/Synet/Utils/ConvParam.h
+++ b/src/Synet/Utils/ConvParam.h
@@ -101,7 +101,7 @@ namespace Synet
             return true;
         }
 
-        template<class T> bool Set(const Tensor<T> & src, const Tensor<T>& dst, bool conv, bool autoPad)
+        bool Set(const Tensor & src, const Tensor& dst, bool conv, bool autoPad)
         {
             if (src.Format() == TensorFormatNhwc)
             {

--- a/src/Synet/Utils/Difference.h
+++ b/src/Synet/Utils/Difference.h
@@ -32,7 +32,7 @@ namespace Synet
     {
     public:
         typedef T Type;
-        typedef Synet::Tensor<T> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<T> Vector;
 
         struct Specific
@@ -135,8 +135,8 @@ namespace Synet
             }
             else
                 return false;
-            _first = first. template Data<Type>();
-            _second = second. template Data<Type>();
+            _first = first.Data<Type>();
+            _second = second.Data<Type>();
             return true;
         }
 

--- a/src/Synet/Utils/Statistics.h
+++ b/src/Synet/Utils/Statistics.h
@@ -147,7 +147,7 @@ namespace Synet
         }
     }
 
-    template <typename T> size_t GetChannels(const Tensor<T>& tensor)
+    SYNET_INLINE size_t GetChannels(const Tensor& tensor)
     {
         if (tensor.Count() == 4)
         {
@@ -161,7 +161,7 @@ namespace Synet
         return 0;
     }
 
-    template <typename T> void UpdateChannelsQuantile(const Tensor<T>& tensor, T quntile, T epsilon, T * lower, T * upper)
+    template <typename T> void UpdateChannelsQuantile(const Tensor& tensor, T quntile, T epsilon, T * lower, T * upper)
     {
         size_t batch = 0, channels = 0, height = 0, width = 0;
         if (tensor.Count() == 4)
@@ -181,16 +181,16 @@ namespace Synet
         size_t threshold = Round(quntile * count);
         if (threshold == 0)
         {
-            Detail::UpdateChannelsMinMax(tensor. template Data<T>(), batch, channels, height, width, tensor.Format(), lower, upper);
+            Detail::UpdateChannelsMinMax(tensor.Data<T>(), batch, channels, height, width, tensor.Format(), lower, upper);
             return;
         }
         std::vector<T> min(channels, std::numeric_limits<T>::max());
         std::vector<T> max(channels, std::numeric_limits<T>::lowest());
-        Detail::UpdateChannelsMinMax(tensor. template Data<T>(), batch, channels, height, width, tensor.Format(), min.data(), max.data());
+        Detail::UpdateChannelsMinMax(tensor.Data<T>(), batch, channels, height, width, tensor.Format(), min.data(), max.data());
         Detail::ValidateMinMax(min.data(), max.data(), channels, epsilon);
         const size_t SIZE = 256;
         std::vector<uint32_t> histogram(channels * SIZE, 0);
-        Detail::UpdateChannelsHistogram(tensor. template Data<T>(), batch, channels, height, width, tensor.Format(), min.data(), max.data(), histogram.data(), SIZE);
+        Detail::UpdateChannelsHistogram(tensor.Data<T>(), batch, channels, height, width, tensor.Format(), min.data(), max.data(), histogram.data(), SIZE);
         Detail::UpdateMinMax(min.data(), max.data(), channels, histogram.data(), SIZE, threshold, lower, upper);
     }
 }

--- a/src/Test/TestMultiThreads.cpp
+++ b/src/Test/TestMultiThreads.cpp
@@ -39,7 +39,7 @@ namespace Test
     typedef Synet::Region<float> Region;
     typedef std::vector<Region> Regions;
     typedef Synet::Floats Floats;
-    typedef Synet::Tensor<float> Tensor;
+    typedef Synet::Tensor Tensor;
     typedef std::vector<Tensor> Tensors;
     typedef Synet::Index Index;
 

--- a/src/Test/TestNetwork.h
+++ b/src/Test/TestNetwork.h
@@ -31,7 +31,7 @@ namespace Test
     typedef Synet::Region<float> Region;
     typedef std::vector<Region> Regions;
     typedef Synet::Floats Floats;
-    typedef Synet::Tensor<float> Tensor;
+    typedef Synet::Tensor Tensor;
     typedef std::vector<Tensor> Tensors;
     typedef Synet::Index Index;
 

--- a/src/Test/TestOpenVino.h
+++ b/src/Test/TestOpenVino.h
@@ -472,7 +472,7 @@ namespace Test
             {
             case ov::element::Type_t::f32:
             {
-                Synet::Tensor<float> tensor(Synet::TensorType32f, dims, format);
+                Synet::Tensor tensor(Synet::TensorType32f, dims, format);
                 const float* pOut = (float*)src.data();
                 SetOutput(dims, strides, 0, pOut, tensor.Data<float>());
                 tensor.DebugPrint(os, "dst[0]", false, first, last, precision);
@@ -480,7 +480,7 @@ namespace Test
             }
             case ov::element::Type_t::i32:
             {
-                Synet::Tensor<int32_t> tensor(Synet::TensorType32i, dims, format);
+                Synet::Tensor tensor(Synet::TensorType32i, dims, format);
                 const int32_t* pOut = (int32_t*)src.data();
                 SetOutput(dims, strides, 0, pOut, tensor.Data<float>());
                 tensor.DebugPrint(os, "dst[0]", false, first, last, precision);
@@ -488,7 +488,7 @@ namespace Test
             }
             case ov::element::Type_t::i64:
             {
-                Synet::Tensor<int64_t> tensor(Synet::TensorType64i, dims, format);
+                Synet::Tensor tensor(Synet::TensorType64i, dims, format);
                 const int64_t* pOut = (int64_t*)src.data();
                 SetOutput(dims, strides, 0, pOut, tensor.Data<float>());
                 tensor.DebugPrint(os, "dst[0]", false, first, last, precision);
@@ -496,7 +496,7 @@ namespace Test
             }
             case ov::element::Type_t::u8:
             {
-                Synet::Tensor<uint8_t> tensor(Synet::TensorType8u, dims, format);
+                Synet::Tensor tensor(Synet::TensorType8u, dims, format);
                 const uint8_t* pOut = (uint8_t*)src.data();
                 SetOutput(dims, strides, 0, pOut, tensor.Data<float>());
                 tensor.DebugPrint(os, "dst[0]", false, first, last, precision);
@@ -504,7 +504,7 @@ namespace Test
             }
             case ov::element::Type_t::i8:
             {
-                Synet::Tensor<int8_t> tensor(Synet::TensorType8i, dims, format);
+                Synet::Tensor tensor(Synet::TensorType8i, dims, format);
                 const int8_t* pOut = (int8_t*)src.data();
                 SetOutput(dims, strides, 0, pOut, tensor.Data<float>());
                 tensor.DebugPrint(os, "dst[0]", false, first, last, precision);

--- a/src/Test/TestOutputComparer.h
+++ b/src/Test/TestOutputComparer.h
@@ -41,7 +41,7 @@ namespace Test
     public:
         typedef Synet::Region<float> Region;
         typedef std::vector<Region> Regions;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
         typedef Synet::Difference<float> Difference;
 

--- a/src/Test/TestStability.cpp
+++ b/src/Test/TestStability.cpp
@@ -34,7 +34,7 @@ namespace Test
     struct Stability
     {
         typedef Synet::Network Network;
-        typedef Synet::Tensor<float> Tensor;
+        typedef Synet::Tensor Tensor;
         typedef std::vector<Tensor> Tensors;
 
         //-----------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`Synet::Tensor` already stores element type as a runtime `TensorType`. The unused class template parameter `T` is removed so `Tensor` is a single non-template type.

### Changes
- Change `template<class T> class Tensor` to `class Tensor`.
- Remove unused `Tensor::Type`, `struct Unknown`, and aliases such as `Tensor32f` / `TensorAny`.
- Update call sites from `Tensor<float>` / `Tensor<T>` to `Tensor`.
- Keep typed access through `Data<T>()` and `GetTensorType<T>()`.
- Fix `Tensor::Export` to use `std::vector::assign` (the old `resize(begin, end)` call was never instantiated while `Tensor` was a template).

### Notes
- `PadConstant4` is called as `PadConstant4<float>` because `T` can no longer be deduced from the tensor type.
- `ConvParam::Set` and `GetChannels` are no longer templates; they operate on `Tensor` directly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d40eb438-dc3e-49ec-a0f1-cadb2c4a9f46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d40eb438-dc3e-49ec-a0f1-cadb2c4a9f46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

