### PR TITLE
*refactoring of ConvertPadNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertNonMaxSuppressionNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertNonZeroNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertNotNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPadNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPreluNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertQLinearAddNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertQLinearAveragePoolNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -207,6 +207,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertConstantOfShapeNode.cpp">
       <Filter>OnnxRuntime\C</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPadNode.cpp">
+      <Filter>OnnxRuntime\P</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPreluNode.cpp">
       <Filter>OnnxRuntime\P</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -135,6 +135,8 @@ namespace Synet
 
     bool ConvertNotNode(const onnx::NodeProto& node, LayerParam& layer);
 
+    bool ConvertPadNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer);
+
     bool ConvertPreluNode(const onnx::NodeProto& node, LayerParams& layers, LayerParam& layer);
 
     bool ConvertQLinearAddNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& srcBin, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertPadNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertPadNode.cpp
@@ -1,0 +1,83 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertPadNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 1, 3))
+            return false;
+
+        layer.type() = Synet::LayerTypePad;
+        String mode;
+        if (!ConvertAtrributeString(node, "mode", mode, true, "constant"))
+            return false;
+        if (mode == "constant")
+            layer.pad().mode() = PadModeConstant;
+        else if (mode == "reflect")
+            layer.pad().mode() = PadModeReflect;
+        else if (mode == "edge")
+            layer.pad().mode() = PadModeEdge;
+        else if (mode == "wrap")
+            layer.pad().mode() = PadModeWrap;
+        else
+            SYNET_ERROR("Unknown type of pad mode: " << mode << " !");
+
+        if (layer.src().size() > 1)
+        {
+            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+            if (src1 == NULL)
+                return false;
+            if (src1->type() != LayerTypeMeta)
+                SYNET_ERROR("Pad src[1] must be Meta type!");
+            if (layer.src().size() > 2)
+            {
+                const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
+                if (src2 == NULL)
+                    return false;
+                if (src2->type() != LayerTypeConst)
+                    SYNET_ERROR("Pad src[2] must be Const type!");
+                if (src2->weight()[0].type() != TensorType32f)
+                    SYNET_ERROR("Pad src[2] must have FP32 type!");
+                if (GetWeight<float>(original, src2->weight()[0])[0] != 0)
+                    SYNET_ERROR("Synet support only pad value == 0!");
+                layer.src().resize(2);
+            }
+        }
+        else
+        {
+            if (!ConvertAtrributeInts(node, "pads", layer.pad().pads()))
+                return false;
+        }
+
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,50 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertPadNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 1, 3))
-                return false;
-
-            layer.type() = Synet::LayerTypePad;
-            String mode;
-            if (!ConvertAtrributeString(node, "mode", mode, true, "constant"))
-                return false;
-            if (mode == "constant")
-                layer.pad().mode() = PadModeConstant;
-            else if (mode == "reflect")
-                layer.pad().mode() = PadModeReflect;
-            else if (mode == "edge")
-                layer.pad().mode() = PadModeEdge;
-            else if (mode == "wrap")
-                layer.pad().mode() = PadModeWrap;
-            else
-                SYNET_ERROR("Unknown type of pad mode: " << mode << " !");
-            
-            if (layer.src().size() > 1)
-            {
-                const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-                if (src1 == NULL || src1->type() != LayerTypeMeta)
-                    return false;
-                if (layer.src().size() > 2)
-                {
-                    const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
-                    if (src2 == NULL || src2->type() != LayerTypeConst || src2->weight()[0].type() != TensorType32f)
-                        return false;
-                    if(GetWeight<float>(original, src2->weight()[0])[0] != 0)
-                        SYNET_ERROR("Synet support only pad value == 0!");
-                    layer.src().resize(2);
-                }
-            }  
-            else
-            {
-                if (!ConvertAtrributeInts(node, "pads", layer.pad().pads()))
-                    return false;
-            }
-
-            return true;
-        }
-
         bool ConvertPowNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer)
         {
             if (!CheckSourceNumber(layer, 2))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertPadNode` out of `OnnxRuntime.h` into a dedicated `ConvertPadNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters` under `OnnxRuntime\P`.
- Add `SYNET_ERROR` messages for Pad source type checks that previously returned `false` without a message (`src[1]` must be Meta; `src[2]` must be Const FP32). Helpers `CheckSourceNumber`, `GetLayer`, `ConvertAtrributeString`, `ConvertAtrributeInts`, and `GetWeight` already report their own errors.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original body plus error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertPadNode.cpp` (alphabetically after `ConvertNotNode.cpp`, `OnnxRuntime\P` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertPadNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` and real ONNX protobuf headers succeeds and exports `Synet::ConvertPadNode`.
- [x] `OnnxRuntime.cpp` compiles with `SYNET_ONNXRUNTIME_ENABLE` and references the free function `Synet::ConvertPadNode`.
- [x] Runtime checks: conversion sets `LayerTypePad` for constant/reflect/edge/wrap (and default constant mode); reports errors for unknown mode, wrong source count, non-Meta `src[1]`, non-Const/`non-FP32` `src[2]`, nonzero pad value, and missing source layer.
- [x] GitHub CI `build_and_test_x86 (13, Release)` passed on this branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e98b3019-2d12-4773-aaae-de4bb862fa97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e98b3019-2d12-4773-aaae-de4bb862fa97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

