### PR TITLE
*refactoring of ConvertPowNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -79,6 +79,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertNonZeroNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertNotNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPadNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPowNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPreluNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertQLinearAddNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertQLinearAveragePoolNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -210,6 +210,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPadNode.cpp">
       <Filter>OnnxRuntime\P</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPowNode.cpp">
+      <Filter>OnnxRuntime\P</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertPreluNode.cpp">
       <Filter>OnnxRuntime\P</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -137,6 +137,8 @@ namespace Synet
 
     bool ConvertPadNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer);
 
+    bool ConvertPowNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer);
+
     bool ConvertPreluNode(const onnx::NodeProto& node, LayerParams& layers, LayerParam& layer);
 
     bool ConvertQLinearAddNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& srcBin, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertPowNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertPowNode.cpp
@@ -1,0 +1,56 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+
+namespace Synet
+{
+    bool ConvertPowNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 2))
+            return false;
+        const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src0 == NULL || src1 == NULL)
+            return false;
+        if (src1->type() == LayerTypeConst && TensorSize(src1->weight()[0].dim()) == 1)
+        {
+            layer.type() = Synet::LayerTypePower;
+            const float* pPower = GetWeight<float>(original, src1->weight()[0]);
+            layer.power().power() = pPower[0];
+            layer.src().resize(1);
+        }
+        else
+        {
+            if (src1->weight().empty())
+                SYNET_ERROR("PowerNode error: src1 { type: " << Cpl::ToStr(src1->type()) << " } is not a scalar constant!");
+            SYNET_ERROR("PowerNode error: src1 { type: " << Cpl::ToStr(src1->type()) << " size: " << TensorSize(src1->weight()[0].dim()) << " }");
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,29 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertPowNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 2))
-                return false;
-            const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src0 == NULL || src1 == NULL)
-                return false;
-            if (src1->type() == LayerTypeConst && TensorSize(src1->weight()[0].dim()) == 1)
-            {
-                layer.type() = Synet::LayerTypePower;
-                const float* pPower = GetWeight<float>(original, src1->weight()[0]);
-                layer.power().power() = pPower[0];
-                layer.src().resize(1);
-            }
-            else
-            {
-                std::cout << "PowerNode error: src1 { type: " << Cpl::ToStr(src1->type()) << " size: " << TensorSize(src1->weight()[0].dim()) << " }" << std::endl;
-                return false;
-            }
-            return true;
-        }
-
         bool ConvertRangeNode(const onnx::NodeProto& node, LayerParams& layers, LayerParam& layer)
         {
             if (!CheckSourceNumber(layer, 3))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertPowNode` out of `OnnxRuntime.h` into a dedicated `ConvertPowNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters` under `OnnxRuntime\P`.
- Replace the previous `std::cout` failure path with `SYNET_ERROR`, and add a message when `src[1]` has no weight. Helpers `CheckSourceNumber`, `GetLayer`, and `GetWeight` already report their own errors.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original body plus error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertPowNode.cpp` (alphabetically after `ConvertPadNode.cpp`, `OnnxRuntime\P` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertPowNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` and real ONNX protobuf headers succeeds and exports `Synet::ConvertPowNode`.
- [x] `OnnxRuntime.cpp` compiles with `SYNET_ONNXRUNTIME_ENABLE` and references the free function `Synet::ConvertPowNode`.
- [x] Runtime checks: scalar Const `src[1]` converts to `LayerTypePower` with the exponent; wrong source count, missing source, and non-scalar/`non-Const` `src[1]` report errors.
- [x] GitHub CI `build_and_test_x86 (13, Release)` passed on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7db5c73c-8986-40d4-bff7-080374721a8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7db5c73c-8986-40d4-bff7-080374721a8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

