### PR TITLE
*refactoring of ConvertReduceSumNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -93,6 +93,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReduceMaxNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReduceMeanNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReduceMinNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReduceSumNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertRoundNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -270,6 +270,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReduceMinNode.cpp">
       <Filter>OnnxRuntime\R</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReduceSumNode.cpp">
+      <Filter>OnnxRuntime\R</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Cvt\OnnxRuntime\OnnxRuntime.h">

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -165,6 +165,8 @@ namespace Synet
 
     bool ConvertReduceMinNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer, TensorFormatMap* tensorFormatMap);
 
+    bool ConvertReduceSumNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer);
+
     bool ConvertRoundNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertSignNode(const onnx::NodeProto& node, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertReduceSumNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertReduceSumNode.cpp
@@ -1,0 +1,70 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertReduceSumNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 1, 2))
+            return false;
+        layer.type() = Synet::LayerTypeReduction;
+        layer.reduction().type() = ReductionTypeSum;
+        if (layer.src().size() == 2)
+        {
+            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+            if (src1 == NULL)
+                return false;
+            if (src1->type() != LayerTypeMeta || src1->meta().type() != Synet::MetaTypeConst)
+                SYNET_ERROR("ReduceSum src[1] must be Meta Const type!");
+            const TensorParam& alpha = src1->meta().alpha();
+            if (alpha.type() != TensorType64i)
+                SYNET_ERROR("ReduceSum src[1] alpha must be TensorType64i!");
+            layer.reduction().axis().resize(alpha.i64().size());
+            for (size_t i = 0; i < alpha.i64().size(); ++i)
+                layer.reduction().axis()[i] = (int)alpha.i64()[i];
+            layer.src().resize(1);
+        }
+        else
+        {
+            if (!ConvertAtrributeInts(node, "axes", layer.reduction().axis()))
+                return false;
+        }
+        if (!ConvertAtrributeInt(node, "keepdims", layer.reduction().keepDims()))
+            return false;
+        if (trans && CurrentTensorFormat(layers, layer.src(), false, true, true) == TensorFormatNhwc)
+        {
+            Ints nchw = Ints({ 0, 3, 1, 2 }), axis = layer.reduction().axis();
+            for (size_t i = 0; i < axis.size(); ++i)
+                layer.reduction().axis()[i] = nchw[axis[i]];
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,41 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertReduceSumNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 1, 2))
-                return false;
-            layer.type() = Synet::LayerTypeReduction;
-            layer.reduction().type() = ReductionTypeSum;
-            if (layer.src().size() == 2)
-            {
-                const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-                if (src1 == NULL || src1->type() != LayerTypeMeta || src1->meta().type() != Synet::MetaTypeConst)
-                    return false;
-                const TensorParam& alpha = src1->meta().alpha();
-                if (alpha.type() != TensorType64i)
-                    return false;
-                layer.reduction().axis().resize(alpha.i64().size());
-                for (size_t i = 0; i < alpha.i64().size(); ++i)
-                    layer.reduction().axis()[i] = (int)alpha.i64()[i];
-                layer.src().resize(1);
-            }
-            else
-            {
-                if (!ConvertAtrributeInts(node, "axes", layer.reduction().axis()))
-                    return false;
-            }
-            if (!ConvertAtrributeInt(node, "keepdims", layer.reduction().keepDims()))
-                return false;
-            if (trans && CurrentTensorFormat(layers, layer.src(), false, true, true) == TensorFormatNhwc)
-            {
-                Ints nchw = Ints({ 0, 3, 1, 2 }), axis = layer.reduction().axis();
-                for (size_t i = 0; i < axis.size(); ++i)
-                    layer.reduction().axis()[i] = nchw[axis[i]];
-            }
-            return true;
-        }
-
         bool ConvertReluNode(const onnx::NodeProto& node, LayerParam& layer)
         {
             layer.type() = Synet::LayerTypeRelu;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertReduceSumNode` out of `OnnxRuntime.h` into a dedicated `ConvertReduceSumNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters` under `OnnxRuntime\R`.
- Add `SYNET_ERROR` messages when `src[1]` is not Meta Const or its alpha is not `TensorType64i`. Helpers `CheckSourceNumber`, `GetLayer`, `ConvertAtrributeInts`, and `ConvertAtrributeInt` already report their own errors.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original body plus error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertReduceSumNode.cpp` (alphabetically after `ConvertReduceMinNode.cpp`, `OnnxRuntime\R` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertReduceSumNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` and real ONNX protobuf headers succeeds and exports `Synet::ConvertReduceSumNode`.
- [x] `OnnxRuntime.cpp` compiles with `SYNET_ONNXRUNTIME_ENABLE` and references the free function `Synet::ConvertReduceSumNode`.
- [x] Runtime checks: axes from `src[1]` Meta Const 64i and from the `axes` attribute convert to `LayerTypeReduction`/`ReductionTypeSum`; NHWC remap `1,2 -> 3,1`; wrong source count, missing source, non-const axes, wrong alpha type, and missing attributes report errors.
- [x] GitHub CI `build_and_test_x86 (13, Release)` passed on this branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a583c2f1-09e0-43f5-8277-8c8f69ad834a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a583c2f1-09e0-43f5-8277-8c8f69ad834a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

