### PR TITLE
*refactoring of ConvertReshapeNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -95,6 +95,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReduceMinNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReduceSumNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReluNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReshapeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertRoundNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -276,6 +276,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReluNode.cpp">
       <Filter>OnnxRuntime\R</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReshapeNode.cpp">
+      <Filter>OnnxRuntime\R</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Cvt\OnnxRuntime\OnnxRuntime.h">

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -169,6 +169,8 @@ namespace Synet
 
     bool ConvertReluNode(const onnx::NodeProto& node, LayerParam& layer);
 
+    bool ConvertReshapeNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const Bytes& original, const OnnxParam& onnxParam, LayerParam& layer, TensorFormatMap* tensorFormatMap);
+
     bool ConvertRoundNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertSignNode(const onnx::NodeProto& node, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertReshapeNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertReshapeNode.cpp
@@ -1,0 +1,91 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+
+namespace Synet
+{
+    bool ConvertReshapeNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const Bytes& original, const OnnxParam& onnxParam, LayerParam& layer, TensorFormatMap* tensorFormatMap)
+    {
+        if (!CheckSourceNumber(layer, 2))
+            return false;
+        const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src0 == NULL || src1 == NULL)
+            return false;
+        if (src1->type() != LayerTypeMeta)
+            SYNET_ERROR("Reshape src[1] must be Meta type!");
+        if (src1->meta().type() == MetaTypeStub)
+        {
+            src1 = GetLayer(layers, src1->src()[0]);
+            if (src1 == NULL)
+                return false;
+        }
+        if (src0->type() == Synet::LayerTypeMeta)
+        {
+            layer.type() = Synet::LayerTypeMeta;
+            layer.meta().type() = Synet::MetaTypeReshape;
+        }
+        else if (src1->meta().type() == MetaTypeConst)
+        {
+            const TensorParam& alpha = src1->meta().alpha();
+            if (alpha.shape().size() != 1)
+                SYNET_ERROR("Reshape src[1] alpha must have 1D shape!");
+            Shape& shape = layer.reshape().shape();
+            layer.type() = LayerTypeReshape;
+            shape = Shp(alpha.i64().data(), alpha.shape()[0]);
+            layer.src().resize(1);
+            if (trans && CurrentTensorFormat(layers, layer.src(), true, false, true, tensorFormatMap) == TensorFormatNhwc)
+            {
+                if (shape.size() == 5)
+                {
+                    shape = Shp(shape[0], shape[3], shape[4], shape[1], shape[2]);
+                }
+                if (shape.size() == 4)
+                {
+                    shape = Shape({ shape[0], shape[2] , shape[3], shape[1] });
+                }
+                if (shape.size() == 3)
+                {
+                    shape = Shape({ shape[0], shape[2] , shape[1] });
+                }
+            }
+        }
+        else
+        {
+            layer.type() = LayerTypeReshape;
+        }
+        if (onnxParam.setReshapeAxis1() && layer.type() == LayerTypeReshape)
+        {
+            layer.reshape().axis() = 1;
+            //if (layer.reshape().shape().size() > 1 && layer.reshape().shape()[0] == 1)
+            //    layer.reshape().shape().erase(layer.reshape().shape().begin(), layer.reshape().shape().begin() + 1);
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,59 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertReshapeNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const Bytes& original, const OnnxParam& onnxParam, LayerParam& layer, TensorFormatMap* tensorFormatMap)
-        {
-            if (!CheckSourceNumber(layer, 2))
-                return false;
-            const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src0 == NULL || src1 == NULL || src1->type() != LayerTypeMeta)
-                return false;
-            if (src1->meta().type() == MetaTypeStub)
-                src1 = GetLayer(layers, src1->src()[0]);
-            if (src0->type() == Synet::LayerTypeMeta)
-            {
-                layer.type() = Synet::LayerTypeMeta;
-                layer.meta().type() = Synet::MetaTypeReshape;
-            }            
-            else if (src1->meta().type() == MetaTypeConst)
-            {
-                const TensorParam & alpha = src1->meta().alpha();
-                if (alpha.shape().size() != 1)
-                    return false;
-                Shape& shape = layer.reshape().shape();
-                layer.type() = LayerTypeReshape;
-                shape = Shp(alpha.i64().data(), alpha.shape()[0]);
-                layer.src().resize(1);
-                if (trans && CurrentTensorFormat(layers, layer.src(), true, false, true, tensorFormatMap) == TensorFormatNhwc)
-                {
-                    if (shape.size() == 5)
-                    {
-                        shape = Shp( shape[0], shape[3], shape[4], shape[1], shape[2]);
-                    }
-                    if (shape.size() == 4)
-                    {
-                        shape = Shape({ shape[0], shape[2] , shape[3], shape[1] });
-                    }
-                    if (shape.size() == 3)
-                    {
-                        shape = Shape({ shape[0], shape[2] , shape[1] });
-                    }
-                }
-            }
-            else
-            {
-                layer.type() = LayerTypeReshape;
-            }
-            if (onnxParam.setReshapeAxis1() && layer.type() == LayerTypeReshape)
-            {
-                layer.reshape().axis() = 1;
-                //if (layer.reshape().shape().size() > 1 && layer.reshape().shape()[0] == 1)
-                //    layer.reshape().shape().erase(layer.reshape().shape().begin(), layer.reshape().shape().begin() + 1);
-            }
-            return true;
-        }
-
         bool ConvertResizeNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer)
         {
             if (layer.src().size() == 4)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertReshapeNode` out of `OnnxRuntime.h` into a dedicated `ConvertReshapeNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters` under `OnnxRuntime\R`.
- Add `SYNET_ERROR` messages for conversion failures that were previously silent (`src[1]` not Meta, alpha not 1D). `CheckSourceNumber` and `GetLayer` already report their own errors.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original conversion logic, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertReshapeNode.cpp` (alphabetically after `ConvertReluNode.cpp`, `OnnxRuntime\R` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertReshapeNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` succeeds and exports `Synet::ConvertReshapeNode`.
- [x] `OnnxRuntime.cpp` compiles with `SYNET_ONNXRUNTIME_ENABLE` and references the free function `Synet::ConvertReshapeNode`.
- [x] Runtime tests: const/meta/stub/dynamic reshape, NHWC permutation, `setReshapeAxis1`, and error messages for non-Meta `src[1]`, non-1D alpha, and wrong source count.
- [x] GitHub CI `build_and_test_x86 (13, Release)` passed on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9def94c7-6452-4dd8-8ab8-d2c27f28b21d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9def94c7-6452-4dd8-8ab8-d2c27f28b21d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

