### PR TITLE
*refactoring of ConvertScaledDotProductAttentionNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -98,6 +98,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReshapeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertResizeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertRoundNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScaledDotProductAttentionNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertRoundNode.cpp">
       <Filter>OnnxRuntime\R</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScaledDotProductAttentionNode.cpp">
+      <Filter>OnnxRuntime\S</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -175,6 +175,8 @@ namespace Synet
 
     bool ConvertRoundNode(const onnx::NodeProto& node, LayerParam& layer);
 
+    bool ConvertScaledDotProductAttentionNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer, Bytes& reordered);
+
     bool ConvertSignNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertSqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertScaledDotProductAttentionNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertScaledDotProductAttentionNode.cpp
@@ -1,0 +1,52 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+
+namespace Synet
+{
+    bool ConvertScaledDotProductAttentionNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer, Bytes& reordered)
+    {
+        if (!CheckSourceNumber(layer, 4))
+            return false;
+        const LayerParam* src3 = GetLayer(layers, layer.src()[3]);
+        if (src3 == NULL)
+            return false;
+        if (src3->type() != LayerTypeConst)
+            SYNET_ERROR("ScaledDotProductAttention src[3] must be Const type!");
+        if (src3->weight().empty())
+            SYNET_ERROR("ScaledDotProductAttention src[3] Const layer has no weight!");
+        if (src3->weight()[0].type() != TensorType32f)
+            SYNET_ERROR("ScaledDotProductAttention src[3] must have FP32 type!");
+        if (src3->weight()[0].dim() != Shp(1))
+            SYNET_ERROR("ScaledDotProductAttention src[3] must have shape {1} !");
+        layer.type() = Synet::LayerTypeScaledDotProductAttention;
+        layer.src().resize(3);
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,18 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertScaledDotProductAttentionNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer, Bytes& reordered)
-        {
-            if (!CheckSourceNumber(layer, 4))
-                return false;
-            const LayerParam* src3 = GetLayer(layers, layer.src()[3]);
-            if (src3 == NULL || src3->type() != LayerTypeConst || src3->weight()[0].type() != TensorType32f || src3->weight()[0].dim() != Shp(1))
-                return false;
-            layer.type() = Synet::LayerTypeScaledDotProductAttention;
-            layer.src().resize(3);
-            return true;
-        }
-
         bool ConvertScatterElementsNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes& original, LayerParam& layer, Bytes& reordered)
         {
             if (!CheckSourceNumber(layer, 3))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertScaledDotProductAttentionNode` out of `OnnxRuntime.h` into a dedicated `ConvertScaledDotProductAttentionNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters` under `OnnxRuntime\S`.
- Add `SYNET_ERROR` messages for ScaledDotProductAttention source checks that previously returned `false` without a message (`src[3]` must be Const FP32 with shape `{1}`). Helpers `CheckSourceNumber` and `GetLayer` already report their own errors.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original conversion logic plus error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertScaledDotProductAttentionNode.cpp` (alphabetically after `ConvertRoundNode.cpp`, `OnnxRuntime\S` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertScaledDotProductAttentionNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` and real ONNX protobuf headers succeeds and exports `Synet::ConvertScaledDotProductAttentionNode`.
- [x] `OnnxRuntime.cpp` compiles with `SYNET_ONNXRUNTIME_ENABLE` and references the free function `Synet::ConvertScaledDotProductAttentionNode`.
- [x] Runtime checks: conversion sets `LayerTypeScaledDotProductAttention` and drops `src[3]`; reports errors for wrong source count, non-Const `src[3]`, missing weight, non-FP32 type, and shape other than `{1}`.
- [x] GitHub CI `build_and_test_x86 (13, Release)` passed on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763094b9-2476-4807-a521-bf0025ae8335?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763094b9-2476-4807-a521-bf0025ae8335&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

