### PR TITLE
*refactoring of ConvertScatterElementsNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertResizeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertRoundNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScaledDotProductAttentionNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScatterElementsNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -255,6 +255,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScaledDotProductAttentionNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScatterElementsNode.cpp">
+      <Filter>OnnxRuntime\S</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -177,6 +177,8 @@ namespace Synet
 
     bool ConvertScaledDotProductAttentionNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer, Bytes& reordered);
 
+    bool ConvertScatterElementsNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes& original, LayerParam& layer, Bytes& reordered);
+
     bool ConvertSignNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertSqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertScatterElementsNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertScatterElementsNode.cpp
@@ -1,0 +1,54 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertScatterElementsNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes& original, LayerParam& layer, Bytes& reordered)
+    {
+        if (!CheckSourceNumber(layer, 3))
+            return false;
+        const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
+        if (src0 == NULL || src1 == NULL || src2 == NULL)
+            return false;
+        layer.type() = Synet::LayerTypeScatterNd;
+        layer.scatter().version() = 1;
+        if (!ConvertAtrributeInt(node, "axis", layer.scatter().axis()))
+            return false;
+        String reduction;
+        if (!ConvertAtrributeString(node, "reduction", reduction))
+            return false;
+        if (reduction != "none")
+            SYNET_ERROR("Unsupported ScatterElements reduction '" << reduction << "' !");
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,25 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertScatterElementsNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes& original, LayerParam& layer, Bytes& reordered)
-        {
-            if (!CheckSourceNumber(layer, 3))
-                return false;
-            const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
-            if (src0 == NULL || src1 == NULL || src2 == NULL)
-                return false;
-            layer.type() = Synet::LayerTypeScatterNd;
-            layer.scatter().version() = 1;
-            if (!ConvertAtrributeInt(node, "axis", layer.scatter().axis()))
-                return false;
-            String reduction;
-            if (!ConvertAtrributeString(node, "reduction", reduction) || reduction != "none")
-                return false;
-            return true;
-        }
-
         bool ConvertScatterNdNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes & original, LayerParam& layer, Bytes& reordered)
         {
             if (!CheckSourceNumber(layer, 3))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertScatterElementsNode` out of `OnnxRuntime.h` into a dedicated `ConvertScatterElementsNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters` under `OnnxRuntime\S`.
- Add a `SYNET_ERROR` message for unsupported ScatterElements `reduction` values. Helpers `CheckSourceNumber`, `GetLayer`, `ConvertAtrributeInt`, and `ConvertAtrributeString` already report their own errors.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original conversion logic plus error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertScatterElementsNode.cpp` (alphabetically after `ConvertScaledDotProductAttentionNode.cpp`, `OnnxRuntime\S` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertScatterElementsNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` and real ONNX protobuf headers succeeds and exports `Synet::ConvertScatterElementsNode`.
- [x] `OnnxRuntime.cpp` compiles with `SYNET_ONNXRUNTIME_ENABLE` and references the free function `Synet::ConvertScatterElementsNode`.
- [x] Runtime checks: conversion sets `LayerTypeScatterNd` version 1 and copies `axis`; reports errors for wrong source count, missing sources, missing `axis`/`reduction` attributes, and unsupported reduction (for example `add`).
- [x] GitHub CI `build_and_test_x86 (13, Release)` passed on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28e91d09-9fe3-427d-adb3-89008b730ba0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28e91d09-9fe3-427d-adb3-89008b730ba0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

