### PR TITLE
*refactoring of ConvertScatterNdNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertRoundNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScaledDotProductAttentionNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScatterElementsNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScatterNdNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -258,6 +258,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScatterElementsNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScatterNdNode.cpp">
+      <Filter>OnnxRuntime\S</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -179,6 +179,8 @@ namespace Synet
 
     bool ConvertScatterElementsNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes& original, LayerParam& layer, Bytes& reordered);
 
+    bool ConvertScatterNdNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes& original, LayerParam& layer, Bytes& reordered);
+
     bool ConvertSignNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertSqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertScatterNdNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertScatterNdNode.cpp
@@ -1,0 +1,68 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+
+namespace Synet
+{
+    bool ConvertScatterNdNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes& original, LayerParam& layer, Bytes& reordered)
+    {
+        if (!CheckSourceNumber(layer, 3))
+            return false;
+        const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
+        if (src0 == NULL || src1 == NULL || src2 == NULL)
+            return false;
+        layer.type() = Synet::LayerTypeScatterNd;
+        if (src1->type() == LayerTypeMeta && src1->meta().type() == MetaTypeConst)
+        {
+            const TensorParam& alpha = src1->meta().alpha();
+            size_t size = TensorSize(alpha.shape()), offset = reordered.size();
+            layer.type() = Synet::LayerTypeScatterNd;
+            layer.weight().resize(1);
+            layer.weight()[0].dim() = alpha.shape();
+            layer.weight()[0].type() = TensorType32i;
+            layer.weight()[0].offset() = offset;
+            layer.weight()[0].size() = size * 4;
+            layer.src().erase(layer.src().begin() + 1);
+            original.resize(offset + size * 4);
+            reordered.resize(offset + size * 4);
+            if (alpha.type() == TensorType64i)
+            {
+                const int64_t* src = alpha.i64().data();
+                int32_t* dst = GetWeight<int32_t>(reordered, layer.weight()[0]);
+                for (size_t i = 0; i < size; ++i)
+                    dst[i] = (int32_t)src[i];
+            }
+            else
+                SYNET_ERROR("ScatterND src[1] type must be meta const int64!");
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,45 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertScatterNdNode(const onnx::NodeProto& node, const LayerParams& layers, Bytes & original, LayerParam& layer, Bytes& reordered)
-        {
-            if (!CheckSourceNumber(layer, 3))
-                return false;
-            const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            const LayerParam* src2 = GetLayer(layers, layer.src()[2]);
-            if (src0 == NULL || src1 == NULL || src2 == NULL)
-                return false;
-            layer.type() = Synet::LayerTypeScatterNd;
-            if (src1->type() == LayerTypeMeta && src1->meta().type() == MetaTypeConst)
-            {
-                const TensorParam & alpha = src1->meta().alpha();
-                size_t size = TensorSize(alpha.shape()), offset = reordered.size();
-                layer.type() = Synet::LayerTypeScatterNd;
-                layer.weight().resize(1);
-                layer.weight()[0].dim() = alpha.shape();
-                layer.weight()[0].type() = TensorType32i;
-                layer.weight()[0].offset() = offset;
-                layer.weight()[0].size() = size * 4;
-                layer.src().erase(layer.src().begin() + 1);
-                original.resize(offset + size * 4);
-                reordered.resize(offset + size * 4);
-                if (alpha.type() == TensorType64i)
-                {
-                    const int64_t* src = alpha.i64().data();
-                    int32_t * dst = GetWeight<int32_t>(reordered, layer.weight()[0]);
-                    for (size_t i = 0; i < size; ++i)
-                        dst[i] = (int32_t)src[i];
-                }
-                else
-                {
-                    std::cout << "src[1] type must be meta const int64!" << std::endl;
-                    return false;
-                }
-            }
-            return true;
-        }
-
         bool ConvertShapeNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const OnnxParam& onnxParam, LayerParam& layer)
         {
             layer.type() = LayerTypeMeta;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertScatterNdNode` out of `OnnxRuntime.h` into a dedicated `ConvertScatterNdNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters` under `OnnxRuntime\S`.
- Replace the `std::cout` conversion error with `SYNET_ERROR` when ScatterND `src[1]` meta const alpha is not int64. Helpers `CheckSourceNumber` and `GetLayer` already report their own errors.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original conversion logic plus error messages, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertScatterNdNode.cpp` (alphabetically after `ConvertScatterElementsNode.cpp`, `OnnxRuntime\S` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertScatterNdNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` succeeds and exports `Synet::ConvertScatterNdNode`.
- [x] Runtime checks: conversion sets `LayerTypeScatterNd`, folds const int64 indices into int32 weight, and keeps dynamic indices as a source.
- [x] Error messages: wrong source count (`CheckSourceNumber`), missing source (`GetLayer`), and non-int64 meta const indices (`SYNET_ERROR`).
- [x] GitHub CI `build_and_test_x86 (13, Release)` passed on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80dad694-97d0-48a1-ac72-e44aa3718e5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80dad694-97d0-48a1-ac72-e44aa3718e5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

