### PR TITLE
*refactoring of ConvertSigmoidNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -102,6 +102,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScatterElementsNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertScatterNdNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertShapeNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSigmoidNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -264,6 +264,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertShapeNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSigmoidNode.cpp">
+      <Filter>OnnxRuntime\S</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSignNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -183,6 +183,8 @@ namespace Synet
 
     bool ConvertShapeNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const OnnxParam& onnxParam, LayerParam& layer);
 
+    bool ConvertSigmoidNode(const onnx::NodeProto& node, LayerParam& layer);
+
     bool ConvertSignNode(const onnx::NodeProto& node, LayerParam& layer);
 
     bool ConvertSqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertSigmoidNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertSigmoidNode.cpp
@@ -1,0 +1,39 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertSigmoidNode(const onnx::NodeProto& node, LayerParam& layer)
+    {
+        layer.type() = Synet::LayerTypeSigmoid;
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,12 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertSigmoidNode(const onnx::NodeProto& node, LayerParam& layer)
-        {
-            layer.type() = Synet::LayerTypeSigmoid;
-            return true;
-        }
-
         bool ConvertSinNode(const onnx::NodeProto& node, LayerParam& layer)
         {
             layer.type() = Synet::LayerTypeUnaryOperation;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `ConvertSigmoidNode` out of `OnnxRuntime.h` into a dedicated `ConvertSigmoidNode.cpp`, matching other ONNX node converters.
- Declare the free function in `Convert.h`.
- Register the new source in `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters` under `OnnxRuntime\S`.
- The original converter has no failing conversion paths and does not call helpers that can fail, so no extra `SYNET_ERROR` messages were added.

## Test plan
- [x] Extraction checks: function removed from `OnnxRuntime.h`, declared in `Convert.h`, definition matches the original conversion logic, call site in `OnnxRuntime.cpp` unchanged.
- [x] VS2022 project files include `ConvertSigmoidNode.cpp` (alphabetically after `ConvertShapeNode.cpp`, `OnnxRuntime\S` filter); CMake `GLOB_RECURSE` already covers `src/Cvt/OnnxRuntime/*.cpp`.
- [x] `g++ -c ConvertSigmoidNode.cpp` succeeds as an empty translation unit when `SYNET_ONNXRUNTIME_ENABLE` is undefined (no exported symbols).
- [x] `g++ -c` with `SYNET_ONNXRUNTIME_ENABLE` succeeds and exports `Synet::ConvertSigmoidNode`.
- [x] Runtime checks: conversion sets `LayerTypeSigmoid`.
- [x] GitHub CI `build_and_test_x86 (13, Release)` on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5e30b46-e32f-4564-9545-48e49396c77a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5e30b46-e32f-4564-9545-48e49396c77a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

