### PR TITLE
*refactoring of ConvertSplitNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -107,6 +107,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSinNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSliceNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSoftmaxNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSplitNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTopKNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -279,6 +279,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSoftmaxNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSplitNode.cpp">
+      <Filter>OnnxRuntime\S</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -193,6 +193,8 @@ namespace Synet
 
     bool ConvertSoftmaxNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const Bytes& original, LayerParam& layer);
 
+    bool ConvertSplitNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer);
+
     bool ConvertSqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);
 
     bool ConvertTileNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer, TensorFormatMap* tensorFormatMap);

--- a/src/Cvt/OnnxRuntime/ConvertSplitNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertSplitNode.cpp
@@ -1,0 +1,67 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertSplitNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 1, 2))
+            return false;
+        if (layer.src().size() == 1)
+        {
+            if (!ConvertAtrributeInts(node, "split", layer.unpack().parts(), true))
+                return false;
+        }
+        else if (layer.src().size() == 2)
+        {
+            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+            if (src1 == NULL)
+                return false;
+            if (src1->type() != LayerTypeMeta || src1->meta().type() != Synet::MetaTypeConst)
+                SYNET_ERROR("Split src[1] must be Meta Const type!");
+            const TensorParam & alpha = src1->meta().alpha();
+            if (alpha.shape().size() != 1)
+                SYNET_ERROR("Split src[1] alpha must have 1D shape!");
+            for (size_t i = 0; i < alpha.shape()[0]; ++i)
+                layer.unpack().parts().push_back((int32_t)alpha.i64()[i]);
+            layer.src().resize(1);
+        }
+        if (!ConvertAtrributeInt(node, "axis", layer.unpack().axis()))
+            return false;
+        layer.type() = Synet::LayerTypeUnpack;
+        if (trans && CurrentTensorFormat(layers, layer.src(), true, false, true, NULL) == TensorFormatNhwc)
+        {
+            Shape nchw = Shape({ 0, 3, 1, 2 });
+            layer.unpack().axis() = nchw[layer.unpack().axis()];
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,40 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertSplitNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 1, 2))
-                return false;
-            if (layer.src().size() == 1)
-            {
-                if (!ConvertAtrributeInts(node, "split", layer.unpack().parts(), true))
-                    return false;
-            }
-            else if (layer.src().size() == 2)
-            {
-                const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-                if (src1->type() == LayerTypeMeta &&  src1->meta().type() == Synet::MetaTypeConst)
-                {
-                    const TensorParam & alpha = src1->meta().alpha();
-                    assert(alpha.shape().size() == 1);
-                    for (size_t i = 0; i < alpha.shape()[0]; ++i)
-                        layer.unpack().parts().push_back((int32_t)alpha.i64()[i]);
-                    layer.src().resize(1);
-                }
-                else
-                    assert(0);
-            }
-            if (!ConvertAtrributeInt(node, "axis", layer.unpack().axis()))
-                return false;
-            layer.type() = Synet::LayerTypeUnpack;
-            if (trans && CurrentTensorFormat(layers, layer.src(), true, false, true, NULL) == TensorFormatNhwc)
-            {
-                Shape nchw = Shape({ 0, 3, 1, 2 });
-                layer.unpack().axis() = nchw[layer.unpack().axis()];
-            }
-            return true;
-        }
-
         bool ConvertSqrtNode(const onnx::NodeProto& node, LayerParam& layer)
         {
             layer.type() = Synet::LayerTypeUnaryOperation;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move `ConvertSplitNode` from `OnnxRuntime.h` into `ConvertSplitNode.cpp` and register the file in the VS2022 CvtOnnx project.

Silent `assert` paths now report `SYNET_ERROR` when helpers do not already log: `Split src[1]` that is not Meta Const, and a split-sizes tensor that is not 1D. `GetLayer`, `ConvertAtrributeInt`, `ConvertAtrributeInts`, and `CheckSourceNumber` already emit errors. The `OnnxRuntime.cpp` caller still reports conversion failure via `ErrorMessage`.

## Changes
- Extract `ConvertSplitNode` to `src/Cvt/OnnxRuntime/ConvertSplitNode.cpp`
- Declare it in `Convert.h`
- Remove the inline implementation from `OnnxRuntime.h`
- Add the new file to `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`
- Add `SYNET_ERROR` messages for conversion failures that previously used `assert`

CMake already globs `src/Cvt/OnnxRuntime/*.cpp`, so no CMake change is required.

## Testing
- Structural checks: declaration in `Convert.h`, implementation in `ConvertSplitNode.cpp`, removed from `OnnxRuntime.h`, VS project entries present.
- Compiled `ConvertSplitNode.cpp` with and without `SYNET_ONNXRUNTIME_ENABLE`.
- Runtime unit tests passed for the 1-input attribute path, optional `split` attribute, 2-input Meta Const path, NHWC axis remap (`1 -> 3`), and the new error messages.

[ConvertSplitNode verification log](/opt/cursor/artifacts/convert_split_node_verification.log)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fac0725-2bc4-4a39-9d08-229b2ed4adb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fac0725-2bc4-4a39-9d08-229b2ed4adb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

