### PR TITLE
*refactoring of ConvertSubNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -110,6 +110,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSplitNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqrtNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSubNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTopKNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTransposeNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -288,6 +288,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSubNode.cpp">
+      <Filter>OnnxRuntime\S</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp">
       <Filter>OnnxRuntime\T</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -199,6 +199,8 @@ namespace Synet
 
     bool ConvertSqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);
 
+    bool ConvertSubNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer, Bytes& reordered);
+
     bool ConvertTileNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer, TensorFormatMap* tensorFormatMap);
 
     bool ConvertTopKNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertSubNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertSubNode.cpp
@@ -1,0 +1,83 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertSubNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer, Bytes& reordered)
+    {
+        if (!CheckSourceNumber(layer, 2))
+            return false;
+        const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
+        const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+        if (src0 == NULL || src1 == NULL)
+            return false;
+        if (src0->type() == LayerTypeMeta && src1->type() == LayerTypeMeta)
+        {
+            layer.type() = LayerTypeMeta;
+            layer.meta().type() = MetaTypeSub;
+        }
+        else if (src1->type() == LayerTypeConst && TensorSize(src1->weight()[0].dim()) == 1)
+        {
+            layer.type() = Synet::LayerTypePower;
+            const float* pShift = GetWeight<float>(original, src1->weight()[0]);
+            layer.power().shift() = -pShift[0];
+            layer.src().resize(1);
+        }
+        else if (src0->type() == LayerTypeConst && TensorSize(src0->weight()[0].dim()) == 1)
+        {
+            layer.type() = Synet::LayerTypePower;
+            layer.power().scale() = -1.0f;
+            const float* pShift = GetWeight<float>(original, src0->weight()[0]);
+            layer.power().shift() = pShift[0];
+            layer.src()[0] = layer.src()[1];
+            layer.src().resize(1);
+        }
+        else if (src1->type() == LayerTypeConst && SignificantDimsCount(src1->weight()[0].dim()) == 1)
+        {
+            layer.type() = Synet::LayerTypeBias;
+            layer.weight() = src1->weight();
+            if (!CompactShape(layer.weight()[0].dim()))
+                return false;
+            const float* pSrc = GetWeight<float>(original, layer.weight()[0]);
+            float* pDst = GetWeight<float>(reordered, layer.weight()[0]);
+            size_t size = TensorSize(layer.weight()[0].dim());
+            for (size_t i = 0; i < size; ++i)
+                pDst[i] = -pSrc[i];
+            layer.src().resize(1);
+        }
+        else
+        {
+            layer.type() = Synet::LayerTypeBinaryOperation;
+            layer.binaryOperation().type() = BinaryOperationTypeSub;
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,56 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertSubNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer, Bytes& reordered)
-        {
-            if (!CheckSourceNumber(layer, 2))
-                return false;
-            const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
-            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-            if (src0 == NULL || src1 == NULL)
-                return false;
-            if (src0->type() == LayerTypeMeta && src1->type() == LayerTypeMeta)
-            {
-                layer.type() = LayerTypeMeta;
-                layer.meta().type() = MetaTypeSub;
-            }
-            else if (src1->type() == LayerTypeConst && TensorSize(src1->weight()[0].dim()) == 1)
-            {
-                layer.type() = Synet::LayerTypePower;
-                const float* pShift = GetWeight<float>(original, src1->weight()[0]);
-                layer.power().shift() = -pShift[0];
-                layer.src().resize(1);
-            }
-            else if (src0->type() == LayerTypeConst && TensorSize(src0->weight()[0].dim()) == 1)
-            {
-                layer.type() = Synet::LayerTypePower;
-                layer.power().scale() = -1.0f;
-                const float* pShift = GetWeight<float>(original, src0->weight()[0]);
-                layer.power().shift() = pShift[0];
-                layer.src()[0] = layer.src()[1];
-                layer.src().resize(1);
-            }
-            else if (src1->type() == LayerTypeConst && SignificantDimsCount(src1->weight()[0].dim()) == 1)
-            {
-                layer.type() = Synet::LayerTypeBias;
-                layer.weight() = src1->weight();
-                if (!CompactShape(layer.weight()[0].dim()))
-                    return false;
-                const float* pSrc = GetWeight<float>(original, layer.weight()[0]);
-                float* pDst = GetWeight<float>(reordered, layer.weight()[0]);
-                size_t size = TensorSize(layer.weight()[0].dim());
-                for (size_t i = 0; i < size; ++i)
-                    pDst[i] = -pSrc[i];
-                layer.src().resize(1);
-            }
-            else
-            {
-                layer.type() = Synet::LayerTypeBinaryOperation;
-                layer.binaryOperation().type() = BinaryOperationTypeSub;
-            }
-            return true;
-        }
-
         bool ConvertTanhNode(const onnx::NodeProto& node, LayerParam& layer)
         {
             layer.type() = Synet::LayerTypeUnaryOperation;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move `ConvertSubNode` from `OnnxRuntime.h` into `ConvertSubNode.cpp` and register the file in the VS2022 CvtOnnx project.

Called helpers (`CheckSourceNumber`, `GetLayer`, `GetWeight`, `CompactShape`) already report conversion errors, so no extra `SYNET_ERROR` messages were added. The `OnnxRuntime.cpp` caller already reports conversion failure via `ErrorMessage`.

## Changes
- Extract `ConvertSubNode` to `src/Cvt/OnnxRuntime/ConvertSubNode.cpp`
- Declare it in `Convert.h`
- Remove the inline implementation from `OnnxRuntime.h`
- Add the new file to `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`

CMake already globs `src/Cvt/OnnxRuntime/*.cpp`, so no CMake change is required.

## Testing
- Structural checks: declaration in `Convert.h`, implementation in `ConvertSubNode.cpp`, removed from `OnnxRuntime.h`, VS project entries present.
- Compiled `ConvertSubNode.cpp` and a `Convert.h` translation unit with `SYNET_ONNXRUNTIME_ENABLE`.
- Ran a unit test covering all conversion paths:
  - wrong source count and missing source layer return false (helpers already log errors)
  - Meta − Meta becomes `LayerTypeMeta` / `MetaTypeSub`
  - scalar Const `src[1]` becomes `Power` with negated shift
  - scalar Const `src[0]` becomes `Power` with scale `-1`
  - one-significant-dim Const `src[1]` becomes `Bias` with negated compacted weights
  - two regular tensors become `BinaryOperation` / `Sub`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3baf5073-21ba-439a-86f9-fbe6d4fd74c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3baf5073-21ba-439a-86f9-fbe6d4fd74c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

