### PR TITLE
*refactoring of ConvertTanhNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -111,6 +111,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqrtNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSqueezeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSubNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTanhNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTopKNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTransposeNode.cpp" />

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -291,6 +291,9 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertSubNode.cpp">
       <Filter>OnnxRuntime\S</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTanhNode.cpp">
+      <Filter>OnnxRuntime\T</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp">
       <Filter>OnnxRuntime\T</Filter>
     </ClCompile>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -201,6 +201,8 @@ namespace Synet
 
     bool ConvertSubNode(const onnx::NodeProto& node, const LayerParams& layers, const Bytes& original, LayerParam& layer, Bytes& reordered);
 
+    bool ConvertTanhNode(const onnx::NodeProto& node, LayerParam& layer);
+
     bool ConvertTileNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, LayerParam& layer, TensorFormatMap* tensorFormatMap);
 
     bool ConvertTopKNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);

--- a/src/Cvt/OnnxRuntime/ConvertTanhNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertTanhNode.cpp
@@ -1,0 +1,40 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertTanhNode(const onnx::NodeProto& node, LayerParam& layer)
+    {
+        layer.type() = Synet::LayerTypeUnaryOperation;
+        layer.unaryOperation().type() = UnaryOperationTypeTanh;
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,13 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertTanhNode(const onnx::NodeProto& node, LayerParam& layer)
-        {
-            layer.type() = Synet::LayerTypeUnaryOperation;
-            layer.unaryOperation().type() = UnaryOperationTypeTanh;
-            return true;
-        }
-
         bool ConvertUnsqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
         {
             if (!CheckSourceNumber(layer, 1, 2))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move `ConvertTanhNode` from `OnnxRuntime.h` into `ConvertTanhNode.cpp` and register the file in the VS2022 CvtOnnx project.

The original converter always succeeds and does not call helpers that can fail, so no extra error messages were added. The `OnnxRuntime.cpp` caller already reports conversion failure via `ErrorMessage`.

## Changes
- Extract `ConvertTanhNode` to `src/Cvt/OnnxRuntime/ConvertTanhNode.cpp`
- Declare it in `Convert.h`
- Remove the inline implementation from `OnnxRuntime.h`
- Add the new file to `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters`

CMake already globs `src/Cvt/OnnxRuntime/*.cpp`, so no CMake change is required.

## Testing
- Structural checks: declaration in `Convert.h`, implementation in `ConvertTanhNode.cpp`, removed from `OnnxRuntime.h`, VS project entries present.
- Compiled `ConvertTanhNode.cpp` and a `Convert.h` translation unit with `SYNET_ONNXRUNTIME_ENABLE`.
- Ran a unit test that calls `ConvertTanhNode` and checks it sets `LayerTypeUnaryOperation` + `UnaryOperationTypeTanh`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-137c3462-e2e8-4689-b79d-be537e958840?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-137c3462-e2e8-4689-b79d-be537e958840&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

