### PR TITLE
*refactoring of ConvertUnsqueezeNode.

### DIFF
--- a/prj/vs2022/CvtOnnx.vcxproj
+++ b/prj/vs2022/CvtOnnx.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTileNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTopKNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTransposeNode.cpp" />
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertUnsqueezeNode.cpp" />
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\OnnxRuntime.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/prj/vs2022/CvtOnnx.vcxproj.filters
+++ b/prj/vs2022/CvtOnnx.vcxproj.filters
@@ -55,6 +55,9 @@
     <Filter Include="OnnxRuntime\T">
       <UniqueIdentifier>{35ab3e4f-b67f-466a-9929-111bfd6f603a}</UniqueIdentifier>
     </Filter>
+    <Filter Include="OnnxRuntime\U">
+      <UniqueIdentifier>{8c6e1d4a-2f7b-4e91-a3c5-9b0d7e4f1a62}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\OnnxRuntime.cpp">
@@ -302,6 +305,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertTransposeNode.cpp">
       <Filter>OnnxRuntime\T</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertUnsqueezeNode.cpp">
+      <Filter>OnnxRuntime\U</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Cvt\OnnxRuntime\ConvertReduceMinNode.cpp">
       <Filter>OnnxRuntime\R</Filter>

--- a/src/Cvt/OnnxRuntime/Convert.h
+++ b/src/Cvt/OnnxRuntime/Convert.h
@@ -208,6 +208,8 @@ namespace Synet
     bool ConvertTopKNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);
 
     bool ConvertTransposeNode(const onnx::NodeProto& node, bool trans, const LayerParams& layers, const OnnxParam& onnxParam, LayerParam& layer, TensorFormatMap* tensorFormatMap);
+
+    bool ConvertUnsqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer);
 }
 
 #endif

--- a/src/Cvt/OnnxRuntime/ConvertUnsqueezeNode.cpp
+++ b/src/Cvt/OnnxRuntime/ConvertUnsqueezeNode.cpp
@@ -1,0 +1,90 @@
+/*
+* Synet Framework (http://github.com/ermig1979/Synet).
+*
+* Copyright (c) 2018-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if defined(SYNET_ONNXRUNTIME_ENABLE)
+
+#include "Cvt/OnnxRuntime/Common.h"
+#include "Cvt/OnnxRuntime/Attribute.h"
+
+namespace Synet
+{
+    bool ConvertUnsqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
+    {
+        if (!CheckSourceNumber(layer, 1, 2))
+            return false;
+        if (layer.src().size() == 1)
+        {
+            const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
+            if (src0 == NULL)
+                return false;
+            if (src0->type() == LayerTypeMeta)
+            {
+                layer.type() = Synet::LayerTypeMeta;
+                layer.meta().type() = Synet::MetaTypeExpandDims;
+                layer.meta().alpha().type() = TensorType64i;
+                if (!ConvertAtrributeInts(node, "axes", layer.meta().alpha().i64()))
+                    return false;
+                layer.meta().alpha().shape().resize(1, layer.meta().alpha().i64().size());
+            }
+            else
+            {
+                layer.type() = Synet::LayerTypeExpandDims;
+                if (!ConvertAtrributeInts(node, "axes", layer.expandDims().axes()))
+                    return false;
+            }
+        }
+        else if (layer.src().size() == 2)
+        {
+            const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
+            const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
+            if (src0 == NULL || src1 == NULL)
+                return false;
+            if (src1->type() != LayerTypeMeta || src1->meta().type() != MetaTypeConst)
+                SYNET_ERROR("Unsqueeze src[1] must be Meta Const type!");
+            const TensorParam & alpha = src1->meta().alpha();
+            if (src0->type() == LayerTypeMeta)
+            {
+                layer.type() = Synet::LayerTypeMeta;
+                layer.meta().type() = Synet::MetaTypeExpandDims;
+                layer.meta().alpha() = alpha;
+            }
+            else
+            {
+                layer.type() = Synet::LayerTypeExpandDims;
+                if (alpha.type() == TensorType64i)
+                {
+                    layer.expandDims().axes().resize(alpha.i64().size());
+                    for (size_t i = 0; i < alpha.i64().size(); ++i)
+                        layer.expandDims().axes()[i] = (int)alpha.i64()[i];
+                }
+                else
+                    SYNET_ERROR("Unsqueeze src[1] alpha must be TensorType64i!");
+            }
+            layer.src().resize(1);
+        }
+        return true;
+    }
+}
+
+#endif

--- a/src/Cvt/OnnxRuntime/OnnxRuntime.h
+++ b/src/Cvt/OnnxRuntime/OnnxRuntime.h
@@ -61,63 +61,6 @@ namespace Synet
 
         //-----------------------------------------------------------------------------------------
 
-        bool ConvertUnsqueezeNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
-        {
-            if (!CheckSourceNumber(layer, 1, 2))
-                return false;
-            if (layer.src().size() == 1)
-            {
-                const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
-                if (src0 == NULL)
-                    return false;
-                if (src0->type() == LayerTypeMeta)
-                {
-                    layer.type() = Synet::LayerTypeMeta;
-                    layer.meta().type() = Synet::MetaTypeExpandDims;
-                    layer.meta().alpha().type() = TensorType64i;
-                    if (!ConvertAtrributeInts(node, "axes", layer.meta().alpha().i64()))
-                        return false;
-                    layer.meta().alpha().shape().resize(1, layer.meta().alpha().i64().size());
-                }
-                else
-                {
-                    layer.type() = Synet::LayerTypeExpandDims;
-                    if (!ConvertAtrributeInts(node, "axes", layer.expandDims().axes()))
-                        return false;
-                }
-            }
-            else if (layer.src().size() == 2)
-            {
-                const LayerParam* src0 = GetLayer(layers, layer.src()[0]);
-                const LayerParam* src1 = GetLayer(layers, layer.src()[1]);
-                if (src0 == NULL || src1 == NULL)
-                    return false;
-                if (src1->type() != LayerTypeMeta || src1->meta().type() != MetaTypeConst)
-                    return false;
-                const TensorParam & alpha = src1->meta().alpha();
-                if (src0->type() == LayerTypeMeta)
-                {
-                    layer.type() = Synet::LayerTypeMeta;
-                    layer.meta().type() = Synet::MetaTypeExpandDims;
-                    layer.meta().alpha() = alpha;
-                }
-                else
-                {
-                    layer.type() = Synet::LayerTypeExpandDims;
-                    if (alpha.type() == TensorType64i)
-                    {
-                        layer.expandDims().axes().resize(alpha.i64().size());
-                        for (size_t i = 0; i < alpha.i64().size(); ++i)
-                            layer.expandDims().axes()[i] = (int)alpha.i64()[i];
-                    }
-                    else
-                        return false;
-                }
-                layer.src().resize(1);
-            }
-            return true;
-        }
-
         bool ConvertWhereNode(const onnx::NodeProto& node, const LayerParams& layers, LayerParam& layer)
         {
             if (!CheckSourceNumber(layer, 3))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move `ConvertUnsqueezeNode` from `OnnxRuntime.h` into `ConvertUnsqueezeNode.cpp` and register the file in the VS2022 CvtOnnx project.

Helpers already used by this converter (`CheckSourceNumber`, `GetLayer`, `ConvertAtrributeInts`) report their own failures. Two silent `return false` paths now emit `SYNET_ERROR` messages:
- `src[1]` is not Meta Const
- `src[1]` alpha is not `TensorType64i`

The `OnnxRuntime.cpp` caller already reports conversion failure via `ErrorMessage`.

## Changes
- Extract `ConvertUnsqueezeNode` to `src/Cvt/OnnxRuntime/ConvertUnsqueezeNode.cpp`
- Declare it in `Convert.h`
- Remove the inline implementation from `OnnxRuntime.h`
- Add the new file to `prj/vs2022/CvtOnnx.vcxproj` and `prj/vs2022/CvtOnnx.vcxproj.filters` under `OnnxRuntime\U`

CMake already globs `src/Cvt/OnnxRuntime/*.cpp`, so no CMake change is required.

## Testing
- Structural checks: declaration in `Convert.h`, implementation in `ConvertUnsqueezeNode.cpp`, removed from `OnnxRuntime.h`, VS project entries present.
- Compiled `ConvertUnsqueezeNode.cpp` and a `Convert.h` translation unit with `SYNET_ONNXRUNTIME_ENABLE`.
- Ran a unit test covering:
  - one-input Meta → `MetaTypeExpandDims`
  - one-input tensor → `LayerTypeExpandDims`
  - two-input Meta Const axes → `MetaTypeExpandDims`
  - two-input tensor + Meta Const int64 axes → `ExpandDims`
  - new errors for non-Meta-Const `src[1]` and non-int64 alpha
  - existing helper errors from `CheckSourceNumber` and `ConvertAtrributeInts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af03db2a-cc41-4645-b0e5-b4c763160cfd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af03db2a-cc41-4645-b0e5-b4c763160cfd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

