### PR TITLE
*move remaining Optimizer helper implementations from Optimizer.h to Optimizer.cpp.

### DIFF
--- a/src/Cvt/Optimizer/Optimizer.cpp
+++ b/src/Cvt/Optimizer/Optimizer.cpp
@@ -271,6 +271,184 @@ namespace Synet
 
     //--------------------------------------------------------------------------------------------------
 
+    bool Optimizer::Rename(const Change & change, LayerParams & layers)
+    {
+        for (size_t i = 0; i < layers.size(); ++i)
+        {
+            for (size_t j = 0; j < layers[i].src().size(); ++j)
+            {
+                if (layers[i].src()[j] == change.first)
+                {
+                    if (layers[i].src()[0] == layers[i].dst()[0] && layers[i].src().size() == 1)
+                        layers[i].dst()[0] = change.second;
+                    layers[i].src()[j] = change.second;
+                }
+            }
+        }
+        return true;
+    }
+
+    //--------------------------------------------------------------------------------------------------
+
+    bool Optimizer::Rename(const Changes & changes, LayerParams & layers)
+    {
+        for (size_t k = 0; k < changes.size(); ++k)
+        {
+            if (!Rename(changes[k], layers))
+                return false;
+        }
+        return true;
+    }
+
+    //--------------------------------------------------------------------------------------------------
+
+    size_t Optimizer::Users(const String& name, const LayerParams& layers, size_t start, const String & parent) const
+    {
+        size_t users = 0;
+        for (size_t i = start; i < layers.size(); ++i)
+        {
+            if (layers[i].parent() != parent)
+                continue;
+            for (size_t j = 0; j < layers[i].src().size(); ++j)
+            {
+                if (layers[i].src()[j] == name)
+                    users++;
+            }
+        }
+        return users;
+    }
+
+    //--------------------------------------------------------------------------------------------------
+
+    bool Optimizer::CanReuse(const LayerParam & layer)
+    {
+        if (layer.type() == LayerTypeSigmoid)
+            return true;
+        if (layer.type() == LayerTypeSwish)
+            return true;
+        //if (layer.type() == LayerTypeScale)
+        //    return true;
+        //if (layer.type() == LayerTypePower)
+        //    return true;
+        if (_param.reuseEltwise() && layer.type() == LayerTypeEltwise)
+            return true;
+        if (layer.type() == LayerTypeRelu)
+            return true;
+        if (layer.type() == LayerTypeGelu)
+            return true;
+        if (layer.type() == LayerTypeSqueezeExcitation)
+            return true;
+        if (layer.type() == LayerTypeSoftmax && layer.softmax().log() == 0)
+            return true;
+        if (layer.type() == LayerTypePooling && layer.pooling().method() == PoolingMethodTypeMax && 
+            layer.pooling().kernel() == Shp(1, 1) && layer.pooling().stride() == Shp(1, 1))
+            return true;
+        if (layer.type() == LayerTypeTiledScale2D)
+            return true;
+        return false;
+    }
+
+    //--------------------------------------------------------------------------------------------------
+
+    bool Optimizer::HasOutput(const Synet::NetworkParam& network, const LayerParam & layer)
+    {
+        for (size_t l = 0; l < layer.dst().size(); ++l)
+            for (size_t d = 0; d < network.dst().size(); ++d)
+                if (layer.dst()[l] == network.dst()[d])
+                    return true;
+        return false;
+    }
+
+    //--------------------------------------------------------------------------------------------------
+
+    bool Optimizer::ReuseLayers(Synet::NetworkParam& network)
+    {
+        if (network.quantization().method() != QuantizationMethodUnknown)
+            return true;
+        LayerParams & layers = network.layers();
+        for (size_t i = 0; i < layers.size(); ++i)
+        {
+            LayerParam & layer = layers[i];
+            if (layer.src().empty())
+                continue;
+            if (Users(layer.src()[0], layers, i, "") > 1)
+                continue;
+            if (i && layer.src()[0] == layers[i - 1].name() && layers[i - 1].type() == LayerTypeConst)
+                continue;
+            if (Users(layer.dst()[0], layers, i + 1, "") == 0)
+                continue;
+            if (HasOutput(network, layer))
+                continue;
+            size_t srcIndex = GetLayerIndex(layers, layer.src()[0]);
+            if (layers[srcIndex].type() == LayerTypeReshape)
+            {
+                if (Users(layers[srcIndex].src()[0], layers, srcIndex, "") > 1)
+                    continue;
+            }
+            if (!CanReuse(layer))
+                continue;
+            if (!Rename(Change(layer.dst()[0], layer.src()[0]), layers))
+                return false;
+            layer.dst()[0] = layer.src()[0];
+        }
+        return true;
+    }
+
+    //--------------------------------------------------------------------------------------------------
+
+    bool Optimizer::IsStub(const LayerParam& layer, const Synet::NetworkParam& network)
+    {
+        if (layer.type() == LayerTypeStub)
+        {
+            if (Users(layer.dst()[0], network.layers(), 0, layer.parent()) > 0)// && !HasOutput(network, layer))
+                return true;
+            const LayerParam* prev = GetLayer(network.layers(), layer.src()[0]);
+            if (prev && prev->type() == LayerTypeDetectionOutput)
+                return true;
+        }
+        if (layer.type() == LayerTypeMeta && layer.meta().type() == MetaTypeStub)
+            return true;
+        if (layer.type() == LayerTypePooling && layer.pooling().method() == PoolingMethodTypeMax &&
+            layer.pooling().kernel() == Shp(1, 1) && layer.pooling().stride() == Shp(1, 1))
+            return true;
+        return false;
+    }
+
+    //--------------------------------------------------------------------------------------------------
+
+    bool Optimizer::RemoveStub(Synet::NetworkParam& network)
+    {
+        LayerParams& layers = network.layers();
+        for (size_t i = 1; i < layers.size(); ++i)
+        {
+            LayerParam & layer = layers[i];
+            if (!IsStub(layer, network))
+                continue;
+            if (layer.src().size() != 1 || layer.dst().size() != 1)
+                continue;
+            if (!Rename(Change(layer.dst()[0], layer.src()[0]), layers))
+                return false;
+            layers.erase(layers.begin() + i);
+            if (i)
+                i--;
+        }
+        return true;
+    }
+
+    //--------------------------------------------------------------------------------------------------
+
+    bool Optimizer::IsNnwc(const NetworkParam& network)
+    {
+        for (size_t i = 0; i < network.layers().size(); ++i)
+        {
+            if (network.layers()[i].weight().size() && network.layers()[i].weight()[0].format() == TensorFormatNhwc)
+                return true;
+        }
+        return false;
+    }
+
+    //--------------------------------------------------------------------------------------------------
+
     bool OptimizeSynetModel(const String& srcXml, const String& srcBin, const String& dstXml, const String & dstBin, const OptimizerParam & param)
     {
         NetworkParamHolder network;

--- a/src/Cvt/Optimizer/Optimizer.h
+++ b/src/Cvt/Optimizer/Optimizer.h
@@ -46,167 +46,23 @@ namespace Synet
 
         bool OptimizeLayers(Synet::NetworkParam& network, Bytes& bin, int stage);
 
-        //-------------------------------------------------------------------------------------------------
+        bool Rename(const Change & change, LayerParams & layers);
 
-        bool Rename(const Change & change, LayerParams & layers)
-        {
-            for (size_t i = 0; i < layers.size(); ++i)
-            {
-                for (size_t j = 0; j < layers[i].src().size(); ++j)
-                {
-                    if (layers[i].src()[j] == change.first)
-                    {
-                        if (layers[i].src()[0] == layers[i].dst()[0] && layers[i].src().size() == 1)
-                            layers[i].dst()[0] = change.second;
-                        layers[i].src()[j] = change.second;
-                    }
-                }
-            }
-            return true;
-        }
+        bool Rename(const Changes & changes, LayerParams & layers);
 
-        bool Rename(const Changes & changes, LayerParams & layers)
-        {
-            for (size_t k = 0; k < changes.size(); ++k)
-            {
-                if (!Rename(changes[k], layers))
-                    return false;
-            }
-            return true;
-        }
+        size_t Users(const String& name, const LayerParams& layers, size_t start, const String & parent) const;
 
-        size_t Users(const String& name, const LayerParams& layers, size_t start, const String & parent) const
-        {
-            size_t users = 0;
-            for (size_t i = start; i < layers.size(); ++i)
-            {
-                if (layers[i].parent() != parent)
-                    continue;
-                for (size_t j = 0; j < layers[i].src().size(); ++j)
-                {
-                    if (layers[i].src()[j] == name)
-                        users++;
-                }
-            }
-            return users;
-        }
+        bool CanReuse(const LayerParam & layer);
 
-        bool CanReuse(const LayerParam & layer)
-        {
-            if (layer.type() == LayerTypeSigmoid)
-                return true;
-            if (layer.type() == LayerTypeSwish)
-                return true;
-            //if (layer.type() == LayerTypeScale)
-            //    return true;
-            //if (layer.type() == LayerTypePower)
-            //    return true;
-            if (_param.reuseEltwise() && layer.type() == LayerTypeEltwise)
-                return true;
-            if (layer.type() == LayerTypeRelu)
-                return true;
-            if (layer.type() == LayerTypeGelu)
-                return true;
-            if (layer.type() == LayerTypeSqueezeExcitation)
-                return true;
-            if (layer.type() == LayerTypeSoftmax && layer.softmax().log() == 0)
-                return true;
-            if (layer.type() == LayerTypePooling && layer.pooling().method() == PoolingMethodTypeMax && 
-                layer.pooling().kernel() == Shp(1, 1) && layer.pooling().stride() == Shp(1, 1))
-                return true;
-            if (layer.type() == LayerTypeTiledScale2D)
-                return true;
-            return false;
-        }
+        bool HasOutput(const Synet::NetworkParam& network, const LayerParam & layer);
 
-        bool HasOutput(const Synet::NetworkParam& network, const LayerParam & layer)
-        {
-            for (size_t l = 0; l < layer.dst().size(); ++l)
-                for (size_t d = 0; d < network.dst().size(); ++d)
-                    if (layer.dst()[l] == network.dst()[d])
-                        return true;
-            return false;
-        }
+        bool ReuseLayers(Synet::NetworkParam& network);
 
-        bool ReuseLayers(Synet::NetworkParam& network)
-        {
-            if (network.quantization().method() != QuantizationMethodUnknown)
-                return true;
-            LayerParams & layers = network.layers();
-            for (size_t i = 0; i < layers.size(); ++i)
-            {
-                LayerParam & layer = layers[i];
-                if (layer.src().empty())
-                    continue;
-                if (Users(layer.src()[0], layers, i, "") > 1)
-                    continue;
-                if (i && layer.src()[0] == layers[i - 1].name() && layers[i - 1].type() == LayerTypeConst)
-                    continue;
-                if (Users(layer.dst()[0], layers, i + 1, "") == 0)
-                    continue;
-                if (HasOutput(network, layer))
-                    continue;
-                size_t srcIndex = GetLayerIndex(layers, layer.src()[0]);
-                if (layers[srcIndex].type() == LayerTypeReshape)
-                {
-                    if (Users(layers[srcIndex].src()[0], layers, srcIndex, "") > 1)
-                        continue;
-                }
-                if (!CanReuse(layer))
-                    continue;
-                if (!Rename(Change(layer.dst()[0], layer.src()[0]), layers))
-                    return false;
-                layer.dst()[0] = layer.src()[0];
-            }
-            return true;
-        }
+        bool IsStub(const LayerParam& layer, const Synet::NetworkParam& network);
 
-        bool IsStub(const LayerParam& layer, const Synet::NetworkParam& network)
-        {
-            if (layer.type() == LayerTypeStub)
-            {
-                if (Users(layer.dst()[0], network.layers(), 0, layer.parent()) > 0)// && !HasOutput(network, layer))
-                    return true;
-                const LayerParam* prev = GetLayer(network.layers(), layer.src()[0]);
-                if (prev && prev->type() == LayerTypeDetectionOutput)
-                    return true;
-            }
-            if (layer.type() == LayerTypeMeta && layer.meta().type() == MetaTypeStub)
-                return true;
-            if (layer.type() == LayerTypePooling && layer.pooling().method() == PoolingMethodTypeMax &&
-                layer.pooling().kernel() == Shp(1, 1) && layer.pooling().stride() == Shp(1, 1))
-                return true;
-            return false;
-        }
+        bool RemoveStub(Synet::NetworkParam& network);
 
-        bool RemoveStub(Synet::NetworkParam& network)
-        {
-            LayerParams& layers = network.layers();
-            for (size_t i = 1; i < layers.size(); ++i)
-            {
-                LayerParam & layer = layers[i];
-                if (!IsStub(layer, network))
-                    continue;
-                if (layer.src().size() != 1 || layer.dst().size() != 1)
-                    continue;
-                if (!Rename(Change(layer.dst()[0], layer.src()[0]), layers))
-                    return false;
-                layers.erase(layers.begin() + i);
-                if (i)
-                    i--;
-            }
-            return true;
-        }
-
-        bool IsNnwc(const NetworkParam& network)
-        {
-            for (size_t i = 0; i < network.layers().size(); ++i)
-            {
-                if (network.layers()[i].weight().size() && network.layers()[i].weight()[0].format() == TensorFormatNhwc)
-                    return true;
-            }
-            return false;
-        }
+        bool IsNnwc(const NetworkParam& network);
     };
 
     //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move remaining `Synet::Optimizer` member implementations out of `src/Cvt/Optimizer/Optimizer.h` into `src/Cvt/Optimizer/Optimizer.cpp`.

The merge/transform helpers were already extracted into dedicated translation units. This change finishes that split for the Optimizer helpers that stay as class members.

## Changes
- Leave declarations in `Optimizer.h` for `Rename`, `Users`, `CanReuse`, `HasOutput`, `ReuseLayers`, `IsStub`, `RemoveStub`, and `IsNnwc`
- Move those implementations to `Optimizer.cpp`

Call sites in `Optimizer::Run` / `Optimizer::OptimizeLayers` are unchanged. CMake already compiles `Optimizer.cpp`, so no CMake or MSVS project change is required.

## Testing
- Compiled all 31 CvtCore translation units (`src/Cvt/Optimizer/*.cpp`, Deoptimizer, InferenceEngine) into `libCvtCore.a`
- `nm` shows each helper defined in `Optimizer.cpp.o`; a translation unit that only includes `Optimizer.h` does not define them
- Behavioral checks through `Optimizer::Run`:
  - `RemoveStub` drops a used Stub layer and rewires the consumer to the stub source
  - identity max pooling (`1x1` kernel/stride) is treated as a stub and removed
  - `ReuseLayers` rewrites a reusable Relu destination onto its source
  - a network output Relu is not rewritten (`HasOutput`)
  - a network with an NHWC convolution still runs (`IsNnwc` path)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c89f74ba-237c-4a37-abc7-cbf24d9a64c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c89f74ba-237c-4a37-abc7-cbf24d9a64c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

